### PR TITLE
Add  function for the number of possible traversals of Grammar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spindle-lib"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.70.0"
 description = "Simple and efficient expression and byte sequence generator for fuzz testing."

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -3,9 +3,15 @@ use crate::Error;
 use crate::{ir, regex::Regex, reserved::*, Visitor};
 
 use arbitrary::{Arbitrary, Unstructured};
-use std::{collections::HashSet, fmt, str::FromStr};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    str::FromStr,
+};
 
-/// A state machine that produces `arbitrary` matching expressions or byte sequences from `Unstructured`.
+const MAX_REP: u32 = 10; // TODO, make interface for user to control this
+
+/// A state machine that produces `Arbitrary` matching expressions or byte sequences from [`Unstructured`](https://docs.rs/arbitrary/latest/arbitrary/struct.Unstructured.html).
 ///
 /// # Implementation
 /// ## Construction
@@ -19,68 +25,112 @@ use std::{collections::HashSet, fmt, str::FromStr};
 /// When a "leaf" state is reached, e.g. a pre-defined rule, regex, or string literal, `Unstructured`
 /// is used to write arbitrary data (except for string literals) to an output buffer.
 #[derive(Debug)]
-pub struct Grammar(Vec<Expr>);
+pub struct Grammar {
+    rules: Vec<Expr>,
+}
 
 impl Grammar {
     /// Returns a resulting `Visitor` after an arbitirary state machine traversal.
     ///
     /// The state machine traversal starts at the first rule in the grammar.
+    ///
+    /// # Parameters
+    /// `max_depth` is nesting limit of rule referencing during the traversal.
+    /// For example, the below grammar generates numbers less than or equal to the `max_depth` parameter.
+    /// ```text
+    /// one   : "1" | two ;
+    /// two   : "2" | three ;
+    /// three : "3" ;
+    /// ```
     pub fn expression<V: Visitor>(
         &self,
         u: &mut Unstructured<'_>,
-        max_depth: Option<usize>,
+        max_depth: Option<u64>,
     ) -> arbitrary::Result<V> {
-        // Maybe there's a smarter way to pre-allocate the buffer,
-        // like predicting or pre-computing arbitrary lengths (but tracking
-        // that requires another data structure).
-        //
-        // It's simple and efficient enough to let 2x Vec growth do it's thing.
         let mut visitor = V::new();
-        let mut to_write = vec![(&self.0[0], 0)]; // always start at first rule
+        let mut to_write = vec![(&self.rules[0], 0)]; // always start at first rule
 
         while let Some((expr, depth)) = to_write.pop() {
-            if depth > max_depth.unwrap_or(usize::MAX) {
+            if depth >= max_depth.unwrap_or(u64::MAX) {
                 return Err(arbitrary::Error::IncorrectFormat);
             }
 
             match expr {
                 Expr::Or(v) => {
                     let arb_index = u.int_in_range(0..=(v.len() - 1))?;
-                    to_write.push((&v[arb_index], depth + 1));
+                    to_write.push((&v[arb_index], depth));
                     visitor.visit_or(arb_index);
                 }
                 Expr::Concat(v) => {
-                    to_write.extend(v.iter().map(|x| (x, depth + 1)));
+                    to_write.extend(v.iter().map(|x| (x, depth)));
                     visitor.visit_concat();
                 }
                 Expr::Optional(x) => {
                     let b = bool::arbitrary(u)?;
                     if b {
-                        to_write.push((x, depth + 1));
+                        to_write.push((x, depth));
                     }
                     visitor.visit_optional(b);
                 }
                 Expr::Repetition(x, min_rep) => {
                     let mut reps = 0;
-                    u.arbitrary_loop(Some(*min_rep), Some(10), |_| {
-                        to_write.push((x, depth + 1));
+                    u.arbitrary_loop(Some(*min_rep), Some(MAX_REP), |_| {
+                        to_write.push((x, depth));
                         reps += 1;
                         Ok(std::ops::ControlFlow::Continue(()))
                     })?;
                     visitor.visit_repetition(reps);
                 }
                 Expr::Reference(index) => {
-                    to_write.push((&self.0[*index], depth + 1));
+                    to_write.push((&self.rules[*index], depth + 1));
                     visitor.visit_reference(*index);
                 }
                 Expr::Literal(s) => visitor.visit_literal(s.as_str()),
                 Expr::Bytes(b) => visitor.visit_bytes(b),
                 Expr::Regex(regex) => regex.visit(&mut visitor, u)?,
-                Expr::Group(x) => to_write.push((x, depth + 1)),
+                Expr::Group(x) => to_write.push((x, depth)),
                 Expr::Predefined(v) => v.visit(&mut visitor, u)?,
             }
         }
         Ok(visitor)
+    }
+
+    /// Returns the number of possible state machine traversals for
+    /// this state machine or `None` if the result exceeds `u64::MAX`.
+    ///
+    /// # Parameters
+    /// `max_depth` is the maximum nested references that the traversal is allowed.
+    /// A `max_depth` of 0 will always return 0.
+    /// `grammar.how_many(depth)` is the number of unique values possible from
+    /// `grammar.expression::<u64>(u, depth)`, barring hash collisions.
+    ///
+    /// # Usage
+    /// Provides a rough possible number of equivalence classes of the grammar,
+    /// which is useful for estimating overall coverage as the fuzzer discovers more
+    /// classes over time.
+    ///
+    /// # Limitations
+    /// 1. No traversals are counted inside of Regex and pre-defined (e.g. String) rules
+    /// i.e. are counted as 1 possible traversal even though many regex expressions or Strings
+    /// are possible.
+    ///
+    /// 2. The result is not aware of duplicate outputs, e.g.
+    /// ```text
+    /// expr : "foo" | "foo" ;
+    /// ```
+    /// counts as 2 traversals, even though every output is "foo".
+    pub fn how_many(&self, max_depth: Option<u64>) -> Option<u64> {
+        // memoize recent `how_many` calculations for reference rules
+        // mem.get((i, j)) = `how_many` for i depth for jth reference
+        let mut mem: HashMap<(u64, usize), Option<u64>> = HashMap::new();
+        let target_depth = max_depth.unwrap_or(u64::MAX);
+        for depth in 0..=target_depth {
+            let res = self.rules[0].how_many(&self.rules, depth, &mut mem)?;
+            if depth == target_depth {
+                return Some(res);
+            }
+        }
+        None
     }
 }
 
@@ -91,7 +141,7 @@ impl Grammar {
 /// (the printed rules are more verbose and order of operations is clearer)
 impl fmt::Display for Grammar {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        for (i, rule) in self.0.iter().enumerate() {
+        for (i, rule) in self.rules.iter().enumerate() {
             writeln!(f, "{}: {}", i, rule)?;
         }
         Ok(())
@@ -111,7 +161,7 @@ impl TryFrom<Vec<(String, ir::Expr)>> for Grammar {
     type Error = Error;
 
     fn try_from(value: Vec<(String, ir::Expr)>) -> Result<Self, Self::Error> {
-        let (mut names, ir_exprs): (Vec<String>, Vec<ir::Expr>) = value.into_iter().unzip();
+        let (names, ir_exprs): (Vec<String>, Vec<ir::Expr>) = value.into_iter().unzip();
 
         if let Some(dups) = find_duplicates(&names) {
             return Err(Error(ErrorRepr::DuplicateVars(dups)));
@@ -121,17 +171,13 @@ impl TryFrom<Vec<(String, ir::Expr)>> for Grammar {
             return Err(Error(ErrorRepr::Reserved(res)));
         }
 
-        names.extend(Predefined::all().map(|s| s.as_str().to_string()));
-
-        let mut exprs = ir_exprs
+        let rules = ir_exprs
             .into_iter()
             .map(|ir_expr| Expr::try_new(ir_expr, &names))
             .collect::<Result<Vec<Expr>, _>>()?;
 
-        exprs.extend(Predefined::all().map(Expr::Predefined));
-
-        assert_eq!(names.len(), exprs.len());
-        Ok(Self(exprs))
+        assert_eq!(names.len(), rules.len());
+        Ok(Self { rules })
     }
 }
 
@@ -153,6 +199,58 @@ enum Expr {
     Bytes(Vec<u8>),
     Group(Box<Expr>),
     Predefined(Predefined),
+}
+
+impl Expr {
+    fn how_many(
+        &self,
+        rules: &[Expr],
+        depth: u64,
+        mem: &mut HashMap<(u64, usize), Option<u64>>,
+    ) -> Option<u64> {
+        if depth == 0 {
+            return Some(0);
+        }
+
+        match self {
+            Self::Or(x) => {
+                let mut res = 0u64;
+                for child in x.iter() {
+                    let sub_res = child.how_many(rules, depth, mem)?;
+                    res = res.checked_add(sub_res)?;
+                }
+                Some(res)
+            }
+            Self::Concat(x) => {
+                let mut res = 1u64;
+                for child in x.iter() {
+                    let sub_res = child.how_many(rules, depth, mem)?;
+                    res = res.checked_mul(sub_res)?;
+                }
+                Some(res)
+            }
+            Self::Optional(x) => 1u64.checked_add(x.how_many(rules, depth, mem)?),
+            Self::Repetition(x, min_reps) => {
+                let mut res = 0u64;
+                let sub_res = x.how_many(rules, depth, mem)?;
+                for used_rep in *min_reps..=MAX_REP {
+                    res = res.checked_add(sub_res.pow(used_rep))?;
+                }
+                Some(res)
+            }
+            Self::Reference(x) => {
+                if let Some(res) = mem.get(&(depth, *x)) {
+                    *res
+                } else {
+                    let res = rules[*x].how_many(rules, depth - 1, mem);
+                    mem.insert((depth, *x), res);
+                    res
+                }
+            }
+            Self::Group(x) => x.how_many(rules, depth, mem),
+            _ => Some(1),
+        }
+    }
 }
 
 fn fmt_w_name<'a>(
@@ -217,7 +315,7 @@ impl Expr {
             ir::Expr::Group(x) => Self::Group(Box::new(Self::try_new(*x, names)?)),
             ir::Expr::Reference(name) => match names.iter().position(|n| *n == name) {
                 Some(i) => Self::Reference(i),
-                None => return Err(Error(ErrorRepr::UnkownVar(name))),
+                None => Self::Predefined(Predefined::from_str(&name).map_err(Error)?),
             },
             ir::Expr::Literal(x) => Self::Literal(x),
             ir::Expr::Regex(r) => {
@@ -231,6 +329,7 @@ impl Expr {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::{rngs::StdRng, RngCore, SeedableRng};
 
     #[test]
     fn catches_duplicates() {
@@ -276,6 +375,177 @@ mod tests {
                 result,
                 Error(ErrorRepr::Reserved(["String".into()].into_iter().collect()))
             )
+        }
+    }
+
+    fn assert_how_many_matches_generations(grammar: &Grammar, depth: u64) {
+        let mut buf = [0u8; 1024];
+        let num_classes = grammar
+            .how_many(Some(depth))
+            .expect("small number of classes") as usize;
+        assert!(num_classes < 10_000);
+        let mut classes = HashSet::<u64>::with_capacity(num_classes);
+
+        let mut rng = StdRng::seed_from_u64(42);
+
+        // pick `num_iterations` to reduce prob of test being accurate
+        // note, not all classes have the same probability of being picked!
+        // note, 400 is tuned
+        let num_iterations = 400 * num_classes;
+
+        for _ in 0..num_iterations {
+            rng.fill_bytes(&mut buf);
+            let mut u = Unstructured::new(&buf);
+            if let Ok(class) = grammar.expression::<u64>(&mut u, Some(depth)) {
+                classes.insert(class);
+            }
+        }
+        assert_eq!(classes.len(), num_classes);
+    }
+
+    #[test]
+    fn how_many_or() {
+        let grammar: Grammar = r#"num : "1" | "2" ;"#.parse().unwrap();
+
+        for max in 1..=10 {
+            assert_eq!(grammar.how_many(Some(max)), Some(2));
+        }
+        assert_eq!(grammar.how_many(None), Some(2));
+        assert_how_many_matches_generations(&grammar, 1);
+    }
+
+    #[test]
+    fn how_many_concat() {
+        let grammar: Grammar = r#"
+            expr : "1" | "2" | num ;
+            num  : ("3" | "4") "." ("5" | "6") ;
+        "#
+        .parse()
+        .unwrap();
+
+        // only a depth of 1 is allowed, so "1" or "2"
+        assert_eq!(grammar.how_many(Some(1)), Some(2));
+        assert_how_many_matches_generations(&grammar, 1);
+
+        // 2 + (2 * 2)
+        // 2: "1" or "2"
+        // 2 * 2: ("3" or "4") * ("5" or "6")
+        assert_eq!(grammar.how_many(Some(2)), Some(6));
+        assert_how_many_matches_generations(&grammar, 2);
+
+        let grammar: Grammar = r#"
+            expr : "1" | "2" | num? ;
+            num  : ("3" | "4") "." ("5" | "6") ;
+        "#
+        .parse()
+        .unwrap();
+        assert_eq!(grammar.how_many(Some(2)), Some(7));
+        assert_how_many_matches_generations(&grammar, 2);
+        assert_eq!(grammar.how_many(None), Some(7));
+    }
+
+    #[test]
+    fn how_many_reps() {
+        let grammar: Grammar = r#"
+            expr : num* ;
+            num  : "0" | "1" ;
+        "#
+        .parse()
+        .unwrap();
+
+        // 0 reps: 1
+        // 1 reps: 2 ("0" or "1")
+        // 2 reps: 2^2
+        // 3 reps: 2^3
+        // ...
+        assert_eq!(grammar.how_many(Some(2)), Some(2047));
+        assert_how_many_matches_generations(&grammar, 2);
+        assert_eq!(grammar.how_many(None), Some(2047));
+    }
+
+    #[test]
+    fn how_many_choice() {
+        let grammar: Grammar = r#"expr : "1"? ;"#.parse().unwrap();
+        assert_eq!(grammar.how_many(Some(2)), Some(2));
+        assert_how_many_matches_generations(&grammar, 2);
+
+        let grammar: Grammar = r#"expr : ("1" | "2" )? ;"#.parse().unwrap();
+        assert_eq!(grammar.how_many(Some(2)), Some(3));
+        assert_how_many_matches_generations(&grammar, 2);
+
+        // "1", "2", "", or "" (outer)
+        let grammar: Grammar = r#"expr : ("1" | "2"? )? ;"#.parse().unwrap();
+        assert_eq!(grammar.how_many(Some(2)), Some(4));
+        assert_how_many_matches_generations(&grammar, 2);
+        assert_eq!(grammar.how_many(None), Some(4));
+    }
+
+    #[test]
+    fn how_many_simpler_math() {
+        let grammar: Grammar = r#"
+            expr   : u16 | expr symbol expr ;
+            symbol : "+" | "-" | "*" | "/" ;
+        "#
+        .parse()
+        .unwrap();
+
+        assert_eq!(grammar.how_many(Some(1)), Some(1));
+        assert_how_many_matches_generations(&grammar, 1);
+
+        // a singular number
+        // two numbers with 4 possible operators
+        // 1 + 4
+        assert_eq!(grammar.how_many(Some(2)), Some(5));
+        assert_how_many_matches_generations(&grammar, 2);
+
+        // combinations are:
+        // 1 singular number
+        // + 5 possible expressions (from above) on the left
+        // * 4 possible symbols
+        // * 5 possible expressions on the right
+        assert_eq!(grammar.how_many(Some(3)), Some(101));
+        assert_how_many_matches_generations(&grammar, 3);
+        assert_eq!(grammar.how_many(None), None);
+    }
+
+    #[test]
+    fn how_many_simple_math() {
+        let grammar: Grammar = r#"
+            expr   : num | expr symbol expr ;
+            symbol : "+" | "-" | "*" | "/" ;
+            num    : nested | "1" | "2" ;
+            nested : u16;
+        "#
+        .parse()
+        .unwrap();
+
+        assert_eq!(grammar.how_many(Some(1)), Some(0));
+        assert_how_many_matches_generations(&grammar, 1);
+        // only "1" and "2" are reachable, `nested` is a reference
+        // and needs one more depth!
+        assert_eq!(grammar.how_many(Some(2)), Some(2));
+        assert_how_many_matches_generations(&grammar, 2);
+
+        // 3 + 2 * 4 * 2
+        assert_eq!(grammar.how_many(Some(3)), Some(19));
+        assert_how_many_matches_generations(&grammar, 3);
+
+        // This grammar is infinitely recursive
+        assert_eq!(grammar.how_many(None), None);
+    }
+
+    #[test]
+    fn how_many_nesting() {
+        let grammar: Grammar = r#"
+            one    : "1" | two ;
+            two    : "2" | three ;
+            three  : "3" ;
+        "#
+        .parse()
+        .unwrap();
+        assert_eq!(grammar.how_many(Some(10)), Some(3));
+        for depth in 0..=3 {
+            assert_how_many_matches_generations(&grammar, depth);
         }
     }
 }

--- a/src/reserved.rs
+++ b/src/reserved.rs
@@ -1,5 +1,7 @@
+use crate::error::ErrorRepr;
 use crate::Visitor;
 use arbitrary::{Arbitrary, Result, Unstructured};
+use std::str::FromStr;
 use std::sync::LazyLock;
 
 /// Illegal attribute names in a grammar.
@@ -27,7 +29,7 @@ pub(crate) fn filter_reserved_keywords(attrs: &[String]) -> Option<Vec<String>> 
 }
 
 /// Fundemental datatypes that implement `Arbitrary` and evaluate to that implementation.
-#[derive(Debug, enum_iterator::Sequence)]
+#[derive(Debug, PartialEq, Eq, enum_iterator::Sequence)]
 #[allow(non_camel_case_types)]
 pub(crate) enum Predefined {
     /// Reference to an arbitrary `String`.
@@ -56,6 +58,30 @@ impl Predefined {
         match self {
             Self::u16 => "u16",
             Self::String => "String",
+        }
+    }
+}
+
+impl FromStr for Predefined {
+    type Err = ErrorRepr;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "u16" => Ok(Self::u16),
+            "String" => Ok(Self::String),
+            _ => Err(ErrorRepr::UnkownVar(String::from(s))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn str_conversions() {
+        for p in Predefined::all() {
+            assert_eq!(p, Predefined::from_str(p.as_str()).unwrap());
         }
     }
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -1,10 +1,11 @@
 use std::str;
 
 /// Defines state that is built during `Grammar::expression`.
+///
 /// This is implemented for
 /// - `String` to produce string expressions
 /// - `Vec<u8>` to produce byte sequences
-/// - `u64` to produce equivalence class IDs of the traversal path.
+/// - `u64` to produce equivalence class IDs of the traversal path. See [`crate::Grammar::how_many`] for more info.
 ///
 /// You can implement this yourself, for example if you want to implement equivalence classes that
 /// - ignore order


### PR DESCRIPTION
This PR adds `how_many` function to `Grammar`. It returns the number of possible traversals of the `Grammar` state machine (with a max depth). In other words,  `grammar.how_many(depth)` is equal to the number of unique values possible from `grammar.expression::<u64>(u, depth)` (barring hash collisions).

A couple of other small changes:
1. `max_depth` in both `how_many` and `expressions` is the maximum nesting in only reference rules (before nested `Expr` inside of `?` or `*`, etc, where 1 deeper). This is easier to reason about for the user, since a depth is how many rows in the grammar you've visited.
2. `Expr::Predefined` are no longer internally wrapped as `Expr::Reference`. This saves memory and makes `max_depth` easier to reason about.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
