### PR TITLE
Avoid branches that are not reachable during traversal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ enum-iterator = "2.1.0"
 fxhash = "0.2.1"
 itoa = "1.0.11"
 regex-syntax = { version = "0.8.5", default-features = false, features = ["std"] }
+ryu = "1.0.20"
 peg = "0.8.5"
 
 [dev-dependencies]

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -16,12 +16,19 @@ fn main() {
     .parse()
     .unwrap();
 
-    loop {
-        let mut buf = [0; 4096];
-        let mut u = rand_u(&mut buf);
-        if let Ok(s) = grammar.expression::<String>(&mut u, Some(100)) {
-            println!("{}", s);
-            break;
+    for depth in 1..=16 {
+        let how_many = grammar.how_many(Some(depth));
+        let how_many_s = if let Some(x) = how_many {
+            x.to_string()
+        } else {
+            String::from(">u64::MAX")
+        };
+        println!("{} possible traversals with depth {}", how_many_s, depth);
+        if how_many.unwrap_or(u64::MAX) > 0 {
+            let mut buf = [0; 4096];
+            let mut u = rand_u(&mut buf);
+            let expr = grammar.expression::<String>(&mut u, Some(depth)).unwrap();
+            println!("example: {}\n", expr);
         }
     }
 }

--- a/examples/math.rs
+++ b/examples/math.rs
@@ -14,7 +14,7 @@ fn main() {
 
     let mut buf = [0; 4096];
     let mut u = rand_u(&mut buf);
-    let sentence: String = grammar.expression(&mut u, None).unwrap();
+    let sentence: String = grammar.expression(&mut u, Some(5)).unwrap();
     println!("{}", sentence);
 
     // This grammar is similar to the well formed math expression grammar,
@@ -30,6 +30,6 @@ fn main() {
 
     let mut buf = [0; 4096];
     let mut u = rand_u(&mut buf);
-    let sentence: String = grammar.expression(&mut u, None).unwrap();
+    let sentence: String = grammar.expression(&mut u, Some(5)).unwrap();
     println!("{}", sentence);
 }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -28,7 +28,7 @@ pub struct Grammar {
     // i.e. memoized results of `how_many` calculated on construction.
     how_many: Vec<Option<u64>>,
 
-    // `reachable[i][k]` == first depth that is reachable by the `i`th branch `Expr`'s `j`th branch.
+    // `reachable[i][j]` == first depth that is reachable by the `i`th branch `Expr`'s `j`th branch.
     // branches are `Expr::Optional`, `Expr::Or`, `Expr::Repetition`.
     // `reachable` is used in `expression`: branches that are not reachable at the current depth are not explored.
     reachable: Vec<Vec<usize>>,

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -29,7 +29,7 @@ pub struct Grammar {
     how_many: Vec<Option<u64>>,
 
     // `reachable[i][j]` == first depth that is reachable by the `i`th branch `Expr`'s `j`th branch.
-    // branches are `Expr::Optional`, `Expr::Or`, `Expr::Repetition`.
+    // Branch `Expr`s are `Expr::Optional`, `Expr::Or`, `Expr::Repetition`.
     // `reachable` is used in `expression`: branches that are not reachable at the current depth are not explored.
     reachable: Vec<Vec<usize>>,
 }
@@ -107,7 +107,7 @@ impl Grammar {
         Ok(visitor)
     }
 
-    /// Returns `true` if the `i`th branch's `j`th branch is reachable at `depth`.
+    /// Returns `true` if the `i`th branch `Expr`s `j`th branch is reachable at `depth`.
     fn reachable(&self, depth: usize, i: usize, j: usize) -> bool {
         depth > self.reachable[i][j]
     }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -5,7 +5,7 @@ use crate::{ir, regex::Regex, reserved::*, Visitor};
 use arbitrary::{Arbitrary, Unstructured};
 use std::{collections::HashSet, fmt, str::FromStr};
 
-const MAX_REP: u32 = 10; // TODO, make interface for user to control this
+const MAX_REP: u32 = 8; // TODO, make interface for user to control this
 
 /// A state machine that produces `Arbitrary` matching expressions or byte sequences from [`Unstructured`](https://docs.rs/arbitrary/latest/arbitrary/struct.Unstructured.html).
 ///
@@ -530,8 +530,8 @@ mod tests {
         // 2 reps: 2^2
         // 3 reps: 2^3
         // ...
-        assert_eq!(grammar.how_many(Some(2)), Some(2047));
-        assert_eq!(grammar.how_many(None), Some(2047));
+        assert_eq!(grammar.how_many(Some(2)), Some(511));
+        assert_eq!(grammar.how_many(None), Some(511));
     }
 
     #[test]
@@ -577,6 +577,16 @@ mod tests {
         assert_eq!(grammar.how_many(Some(3)), Some(101));
         assert_how_many_matches_generations(&grammar, 3);
         assert_eq!(grammar.how_many(None), None);
+    }
+
+    #[test]
+    fn how_many_with_prefined() {
+        let grammar: Grammar = r#"
+            one : "1" | "2" | (u16 | String)? | u16? | (u16 | String)* ;
+        "#
+        .parse()
+        .unwrap();
+        assert_how_many_matches_generations(&grammar, 2);
     }
 
     #[test]

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -749,10 +749,28 @@ mod tests {
     }
 
     #[test]
+    fn avoid_example() {
+        let grammar: Grammar = r#"
+            one : "1" | two three ;
+            two : "2" "2"? ;
+            three : three_inner ;
+            three_inner : "3"   ;
+        "#
+        .parse()
+        .unwrap();
+
+        for depth in 1..=8 {
+            let valid = success_count(&grammar, depth, 100);
+            assert_eq!(valid, 100);
+            assert_how_many_matches_generations(&grammar, depth);
+        }
+    }
+
+    #[test]
     fn avoid_mixed_branches() {
         let grammar: Grammar = r#"
             expr : "qwerty"* | "4" | (two)? ;
-            two : "5"* | three | four? ;
+            two : "5"* | three | three four? ;
             three : two | three ;
             four  : "4" ;
         "#

--- a/src/reserved.rs
+++ b/src/reserved.rs
@@ -32,20 +32,43 @@ pub(crate) fn filter_reserved_keywords(attrs: &[String]) -> Option<Vec<String>> 
 #[derive(Debug, PartialEq, Eq, enum_iterator::Sequence)]
 #[allow(non_camel_case_types)]
 pub(crate) enum Predefined {
-    /// Reference to an arbitrary `String`.
     String,
-    /// Reference to an arbitrary `u16`.
+    char,
+    u8,
     u16,
+    u32,
+    u64,
+    u128,
+    usize,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    isize,
+    f32,
+    f64,
 }
 
 impl Predefined {
     pub(crate) fn visit<V: Visitor>(&self, v: &mut V, u: &mut Unstructured<'_>) -> Result<()> {
         match self {
-            Self::u16 => {
-                let x = u16::arbitrary(u)?;
-                v.visit_u16(x);
-            }
             Self::String => v.visit_str(<&str as Arbitrary>::arbitrary(u)?),
+            Self::char => v.visit_char(char::arbitrary(u)?),
+            Self::u8 => v.visit_u8(u8::arbitrary(u)?),
+            Self::u16 => v.visit_u16(u16::arbitrary(u)?),
+            Self::u32 => v.visit_u32(u32::arbitrary(u)?),
+            Self::u64 => v.visit_u64(u64::arbitrary(u)?),
+            Self::u128 => v.visit_u128(u128::arbitrary(u)?),
+            Self::usize => v.visit_usize(usize::arbitrary(u)?),
+            Self::i8 => v.visit_i8(i8::arbitrary(u)?),
+            Self::i16 => v.visit_i16(i16::arbitrary(u)?),
+            Self::i32 => v.visit_i32(i32::arbitrary(u)?),
+            Self::i64 => v.visit_i64(i64::arbitrary(u)?),
+            Self::i128 => v.visit_i128(i128::arbitrary(u)?),
+            Self::isize => v.visit_isize(isize::arbitrary(u)?),
+            Self::f32 => v.visit_f32(f32::arbitrary(u)?),
+            Self::f64 => v.visit_f64(f64::arbitrary(u)?),
         }
         Ok(())
     }
@@ -56,8 +79,22 @@ impl Predefined {
 
     pub(crate) const fn as_str(&self) -> &'static str {
         match self {
-            Self::u16 => "u16",
             Self::String => "String",
+            Self::char => "char",
+            Self::u8 => "u8",
+            Self::u16 => "u16",
+            Self::u32 => "u32",
+            Self::u64 => "u64",
+            Self::u128 => "u128",
+            Self::usize => "usize",
+            Self::i8 => "i8",
+            Self::i16 => "i16",
+            Self::i32 => "i32",
+            Self::i64 => "i64",
+            Self::i128 => "i128",
+            Self::isize => "isize",
+            Self::f32 => "f32",
+            Self::f64 => "f64",
         }
     }
 }
@@ -67,8 +104,22 @@ impl FromStr for Predefined {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "u16" => Ok(Self::u16),
             "String" => Ok(Self::String),
+            "char" => Ok(Self::char),
+            "u8" => Ok(Self::u8),
+            "u16" => Ok(Self::u16),
+            "u32" => Ok(Self::u32),
+            "u64" => Ok(Self::u64),
+            "u128" => Ok(Self::u128),
+            "usize" => Ok(Self::usize),
+            "i8" => Ok(Self::i8),
+            "i16" => Ok(Self::i16),
+            "i32" => Ok(Self::i32),
+            "i64" => Ok(Self::i64),
+            "i128" => Ok(Self::i128),
+            "isize" => Ok(Self::isize),
+            "f32" => Ok(Self::f32),
+            "f64" => Ok(Self::f64),
             _ => Err(ErrorRepr::UnkownVar(String::from(s))),
         }
     }
@@ -77,11 +128,119 @@ impl FromStr for Predefined {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Grammar;
+    use rand::{rngs::StdRng, RngCore, SeedableRng};
 
     #[test]
     fn str_conversions() {
         for p in Predefined::all() {
             assert_eq!(p, Predefined::from_str(p.as_str()).unwrap());
+        }
+    }
+
+    macro_rules! test_integer {
+        ($($fn_name:ident = $type:ident),* $(,)*) => (
+            $(
+                #[test]
+                fn $fn_name() {
+                    let s = format!("expr: {} ;", stringify!($type));
+                    let grammar: Grammar = s.parse().unwrap();
+
+                    let mut buf = [0u8; 64];
+                    let mut rng = StdRng::seed_from_u64(42);
+
+                    let mut min_gen = $type::MAX;
+                    let mut max_gen = $type::MIN;
+
+                    for _ in 0..1000 {
+                        rng.fill_bytes(&mut buf);
+                        let mut u = Unstructured::new(&buf);
+                        let expr = grammar.expression::<String>(&mut u, None).unwrap();
+                        // checks that generated numbers are not outside the bounds of MIN and MAX
+                        let x = expr.parse::<$type>().unwrap();
+                        min_gen = std::cmp::min(min_gen, x);
+                        max_gen = std::cmp::max(max_gen, x);
+                    }
+                    // check that generated numbers pretty close to MIN and MAX
+                    // e.g. `u64` isn't generating only `u8`s.
+
+                    // compare the min and max generated numbers to the range of the space.
+                    // Example:
+                    // u16 half range is 32767. if u16 is generating u8s, then the largest `max_gen`
+                    // is 255. 255 is not "close enough" to u16::MAX because 32767 > (65535 - 255) is not true.
+                    // it is unlikely that u16's generates all 1000 numbers less than 255.
+                    // Visualizaiton:
+                    // [0    u8::MAX       u16::MAX]
+                    //                ^ `max_gen` should land somewhere here
+                    let half_range = ($type::MAX / 2) -  ($type::MIN / 2);
+                    let min_diff = min_gen - $type::MIN;
+                    let max_diff = $type::MAX - max_gen;
+                    // 64 is arbitrary and tightens the validation a bit.
+                    assert!(half_range / 64 > max_diff);
+                    assert!(half_range / 64 > min_diff);
+                }
+            )*
+        )
+    }
+
+    test_integer!(
+        test_u8 = u8,
+        test_u16 = u16,
+        test_u32 = u32,
+        test_u64 = u64,
+        test_u128 = u128,
+        test_usize = usize,
+        test_i8 = i8,
+        test_i16 = i16,
+        test_i32 = i32,
+        test_i64 = i64,
+        test_i128 = i128,
+        test_isize = isize,
+    );
+
+    #[test]
+    fn test_char() {
+        let grammar: Grammar = "expr: char ;".parse().unwrap();
+
+        let mut buf = [0u8; 64];
+        let mut rng = StdRng::seed_from_u64(42);
+
+        for _ in 0..1000 {
+            rng.fill_bytes(&mut buf);
+            let mut u = Unstructured::new(&buf);
+            let expr = grammar.expression::<String>(&mut u, None).unwrap();
+            assert_eq!(1, expr.chars().count());
+            assert!(expr.parse::<char>().is_ok());
+        }
+    }
+
+    #[test]
+    fn test_f32() {
+        let grammar: Grammar = "expr: f32 ;".parse().unwrap();
+
+        let mut buf = [0u8; 64];
+        let mut rng = StdRng::seed_from_u64(42);
+
+        for _ in 0..1000 {
+            rng.fill_bytes(&mut buf);
+            let mut u = Unstructured::new(&buf);
+            let expr = grammar.expression::<String>(&mut u, None).unwrap();
+            assert!(expr.parse::<f32>().is_ok());
+        }
+    }
+
+    #[test]
+    fn test_f64() {
+        let grammar: Grammar = "expr: f64 ;".parse().unwrap();
+
+        let mut buf = [0u8; 64];
+        let mut rng = StdRng::seed_from_u64(42);
+
+        for _ in 0..1000 {
+            rng.fill_bytes(&mut buf);
+            let mut u = Unstructured::new(&buf);
+            let expr = grammar.expression::<String>(&mut u, None).unwrap();
+            assert!(expr.parse::<f64>().is_ok());
         }
     }
 }


### PR DESCRIPTION
# Problem
Many traversals are cancelled if the depth exceeds `max_depth`:
```rust
if depth >= max_depth.unwrap_or(usize::MAX) {
    return Err(arbitrary::Error::IncorrectFormat);
}
```
this leads to wasted traversals that lead to no generated expression!

In a simple example, only half the calls to `expression` result in `Ok` for max_depth 1:
```
one : two?;
two : "2" ; // requires depth 2 even though half the paths end up here
```

# Solution
This PR solved this by augmenting the `how_many` calculation to store whether or not a "branch" `Expr` is "reachable" (how_many > 0) for a depth. Branch `Expr` force the traversal to make an arbitrary decision on what path to take (during `expression`):
- `Expr::Optional`: either nothing (always reachable) or some child evaluation.
- `Expr::Repetition`: either nothing (for min_reps == 0) or multiple child evaluations.
- `Expr::Or`: choose one child evaluation.

This PR builds and uses `reachable`, the smallest depth that is reachable by each branch in each "branch" Expr, in 4 steps:
1. Each branch rule is assigned and ID, i.e. index order in the state machines entire pre-order traversal. This is stored as `usize` in the enum `Expr`.
2. The shape of `reachable` is built during `Expr::try_from` (this is when we discover how many branches there are)
3. The values in `reachable` are calculated inline with the augmented `how_many` calculation.
4. During `expression`, branches that are not reachable at the current depth are never taken.

Also, since the implementation in step 3 is really similar to `how_many` from `main` we'll just inline them and cache the `how_many` results.

# Example
```
one : "1" | two three ;
two : "2" "2"? ;
three : three_inner ;
three_inner : "3"   ;
```
After parsing, the entire state machine is
```
[
 Or([Literal("1"), Concat([Reference(2), Reference(1)])], 0), 
 Concat([Optional(Literal("2"), 1), Literal("2")]), 
 Reference(3), 
 Literal("3")
]
```
Step 1:
There are 2 total `Expr` that have branches:
1. `Or([...], 0)` i == 0
2. `Optional(Literal("2"), 1)` i == 1

Step 2:
The shape is `[[0, 0], [0]]`:
- i == 0: 2 possible options, `"1"` OR `two three`
- i == 1: 1 interesting option, "2" if taken (not taking the `?` is always reachable) 

Step 3:
After filling in the values: `[[0, 2], [0]]`:
- i == 0, j == 0 the "1" is reachable at any depth.
- i == 0, j == 1 the `two three` is only reachable at depth 2, since we need to reach all the way to the nested `three_inner` (`one` -> `three` -> `three_inner`).
- i == 1, j == 0 the optional "2" is always reachable when at the `two` rule.

Step 4:
When generating an expression with max_depth == 1:
1. we start at rule `one` with `depth == 1`. 
2. Then we move from rule `one` to `Or([...], 0)`, since it's our only option (and `depth` stays at 1 since we only decrement it when going to a new reference rule). 
3. From `Or([...], 0)`, we can either evaluate `"1"` or `two three`. Since `two three` is not reachable, we choose "1" (`depth > reachable[0][1]` i.e. `1 < 2`).




# "Demo"
Expressions rarely throw an error since we are always taking reachable paths! For the JSON grammar:
```
0 possible traversals with depth 1
0 possible traversals with depth 2
0 possible traversals with depth 3
0 possible traversals with depth 4
1 possible traversals with depth 5
example: {"osN_Oun": "FUIGQoRFzu0"}

2 possible traversals with depth 6
example: {"2lg5zJw": "EuXgT"}

3 possible traversals with depth 7
example: {"D": "lxBu", "UHPwTOKEyDu": "g"}

8 possible traversals with depth 8
example: {"TM": ["Pb0RQww"]}

36 possible traversals with depth 9
example: {"VVDErne": ["9SAcPO"]}

222 possible traversals with depth 10
example: {"HLd": "WeoxCz28"}

2676 possible traversals with depth 11
example: {"YIkBS": {"0KQqkH": "RE3Ou"}}

120465 possible traversals with depth 12
example: {"he": "I2", "BPOBIaghks": "ctF99mrF"}

31200694 possible traversals with depth 13
example: {"A2": {"8uF6K9": {"YOb": "53murYeq4s"}, "LE": "5ut2d2jY"}, "_TK9": "LT5R2Outuxq"}

90450814805 possible traversals with depth 14
example: {"gVZdtN1": "IwGCGzNteEF", "XrBIydM_": "wmP5QB"}

11138294236840452 possible traversals with depth 15
example: {"L5dHX6s0": "Q4O4a9ng"}

>u64::MAX possible traversals with depth 16
example: {"MffjQStk": [{"aPjGTiGRZgA": ["0LbXJ2H", "7ehM"]}], "7_0LX": {"0CvJ5Wcn9Q_": {"vm4PvMbTfC": "DeTlJf5LPK", "cmhkNwBXc": "jJa30UeM0", "j3": "0GpwHxKvpj"}, "lOVKe": {"4oRwfwZ": "o98dDKUh"}}, "j1R6i": ["_1djcRHVcgH", ["_"]], "kVOYEo": "BJ5mgBZ", "wqdfwHS": ["taiJNn", ["EvDaWvTBb"]], "ZBXbdtK": ["criIdNSM"]}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
