### PR TITLE
Add basic predefined types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ enum-iterator = "2.1.0"
 fxhash = "0.2.1"
 itoa = "1.0.11"
 regex-syntax = { version = "0.8.5", default-features = false, features = ["std"] }
+ryu = "1.0.20"
 peg = "0.8.5"
 
 [dev-dependencies]

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -5,7 +5,7 @@ use crate::{ir, regex::Regex, reserved::*, Visitor};
 use arbitrary::{Arbitrary, Unstructured};
 use std::{collections::HashSet, fmt, str::FromStr};
 
-const MAX_REP: u32 = 10; // TODO, make interface for user to control this
+const MAX_REP: u32 = 8; // TODO, make interface for user to control this
 
 /// A state machine that produces `Arbitrary` matching expressions or byte sequences from [`Unstructured`](https://docs.rs/arbitrary/latest/arbitrary/struct.Unstructured.html).
 ///
@@ -455,8 +455,8 @@ mod tests {
         // 2 reps: 2^2
         // 3 reps: 2^3
         // ...
-        assert_eq!(grammar.how_many(Some(2)), Some(2047));
-        assert_eq!(grammar.how_many(None), Some(2047));
+        assert_eq!(grammar.how_many(Some(2)), Some(511));
+        assert_eq!(grammar.how_many(None), Some(511));
     }
 
     #[test]
@@ -502,6 +502,16 @@ mod tests {
         assert_eq!(grammar.how_many(Some(3)), Some(101));
         assert_how_many_matches_generations(&grammar, 3);
         assert_eq!(grammar.how_many(None), None);
+    }
+
+    #[test]
+    fn how_many_with_prefined() {
+        let grammar: Grammar = r#"
+            one : "1" | "2" | (u16 | String)? | u16? | (u16 | String)* ;
+        "#
+        .parse()
+        .unwrap();
+        assert_how_many_matches_generations(&grammar, 2);
     }
 
     #[test]

--- a/src/reserved.rs
+++ b/src/reserved.rs
@@ -32,20 +32,43 @@ pub(crate) fn filter_reserved_keywords(attrs: &[String]) -> Option<Vec<String>> 
 #[derive(Debug, PartialEq, Eq, enum_iterator::Sequence)]
 #[allow(non_camel_case_types)]
 pub(crate) enum Predefined {
-    /// Reference to an arbitrary `String`.
     String,
-    /// Reference to an arbitrary `u16`.
+    char,
+    u8,
     u16,
+    u32,
+    u64,
+    u128,
+    usize,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    isize,
+    f32,
+    f64,
 }
 
 impl Predefined {
     pub(crate) fn visit<V: Visitor>(&self, v: &mut V, u: &mut Unstructured<'_>) -> Result<()> {
         match self {
-            Self::u16 => {
-                let x = u16::arbitrary(u)?;
-                v.visit_u16(x);
-            }
             Self::String => v.visit_str(<&str as Arbitrary>::arbitrary(u)?),
+            Self::char => v.visit_char(char::arbitrary(u)?),
+            Self::u8 => v.visit_u8(u8::arbitrary(u)?),
+            Self::u16 => v.visit_u16(u16::arbitrary(u)?),
+            Self::u32 => v.visit_u32(u32::arbitrary(u)?),
+            Self::u64 => v.visit_u64(u64::arbitrary(u)?),
+            Self::u128 => v.visit_u128(u128::arbitrary(u)?),
+            Self::usize => v.visit_usize(usize::arbitrary(u)?),
+            Self::i8 => v.visit_i8(i8::arbitrary(u)?),
+            Self::i16 => v.visit_i16(i16::arbitrary(u)?),
+            Self::i32 => v.visit_i32(i32::arbitrary(u)?),
+            Self::i64 => v.visit_i64(i64::arbitrary(u)?),
+            Self::i128 => v.visit_i128(i128::arbitrary(u)?),
+            Self::isize => v.visit_isize(isize::arbitrary(u)?),
+            Self::f32 => v.visit_f32(f32::arbitrary(u)?),
+            Self::f64 => v.visit_f64(f64::arbitrary(u)?),
         }
         Ok(())
     }
@@ -56,8 +79,22 @@ impl Predefined {
 
     pub(crate) const fn as_str(&self) -> &'static str {
         match self {
-            Self::u16 => "u16",
             Self::String => "String",
+            Self::char => "char",
+            Self::u8 => "u8",
+            Self::u16 => "u16",
+            Self::u32 => "u32",
+            Self::u64 => "u64",
+            Self::u128 => "u128",
+            Self::usize => "usize",
+            Self::i8 => "i8",
+            Self::i16 => "i16",
+            Self::i32 => "i32",
+            Self::i64 => "i64",
+            Self::i128 => "i128",
+            Self::isize => "isize",
+            Self::f32 => "f32",
+            Self::f64 => "f64",
         }
     }
 }
@@ -67,8 +104,22 @@ impl FromStr for Predefined {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "u16" => Ok(Self::u16),
             "String" => Ok(Self::String),
+            "char" => Ok(Self::char),
+            "u8" => Ok(Self::u8),
+            "u16" => Ok(Self::u16),
+            "u32" => Ok(Self::u32),
+            "u64" => Ok(Self::u64),
+            "u128" => Ok(Self::u128),
+            "usize" => Ok(Self::usize),
+            "i8" => Ok(Self::i8),
+            "i16" => Ok(Self::i16),
+            "i32" => Ok(Self::i32),
+            "i64" => Ok(Self::i64),
+            "i128" => Ok(Self::i128),
+            "isize" => Ok(Self::isize),
+            "f32" => Ok(Self::f32),
+            "f64" => Ok(Self::f64),
             _ => Err(ErrorRepr::UnkownVar(String::from(s))),
         }
     }
@@ -77,11 +128,119 @@ impl FromStr for Predefined {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Grammar;
+    use rand::{rngs::StdRng, RngCore, SeedableRng};
 
     #[test]
     fn str_conversions() {
         for p in Predefined::all() {
             assert_eq!(p, Predefined::from_str(p.as_str()).unwrap());
+        }
+    }
+
+    macro_rules! test_integer {
+        ($($fn_name:ident = $type:ident),* $(,)*) => (
+            $(
+                #[test]
+                fn $fn_name() {
+                    let s = format!("expr: {} ;", stringify!($type));
+                    let grammar: Grammar = s.parse().unwrap();
+
+                    let mut buf = [0u8; 64];
+                    let mut rng = StdRng::seed_from_u64(42);
+
+                    let mut min_gen = $type::MAX;
+                    let mut max_gen = $type::MIN;
+
+                    for _ in 0..1000 {
+                        rng.fill_bytes(&mut buf);
+                        let mut u = Unstructured::new(&buf);
+                        let expr = grammar.expression::<String>(&mut u, None).unwrap();
+                        // checks that generated numbers are not outside the bounds of MIN and MAX
+                        let x = expr.parse::<$type>().unwrap();
+                        min_gen = std::cmp::min(min_gen, x);
+                        max_gen = std::cmp::max(max_gen, x);
+                    }
+                    // check that generated numbers pretty close to MIN and MAX
+                    // e.g. `u64` isn't generating only `u8`s.
+
+                    // compare the min and max generated numbers to the range of the space.
+                    // Example:
+                    // u16 half range is 32767. if u16 is generating u8s, then the largest `max_gen`
+                    // is 255. 255 is not "close enough" to u16::MAX because 32767 > (65535 - 255) is not true.
+                    // it is unlikely that u16's generates all 1000 numbers less than 255.
+                    // Visualizaiton:
+                    // [0    u8::MAX       u16::MAX]
+                    //                ^ `max_gen` should land somewhere here
+                    let half_range = ($type::MAX / 2) -  ($type::MIN / 2);
+                    let min_diff = min_gen - $type::MIN;
+                    let max_diff = $type::MAX - max_gen;
+                    // 64 is arbitrary and tightens the validation a bit.
+                    assert!(half_range / 64 > max_diff);
+                    assert!(half_range / 64 > min_diff);
+                }
+            )*
+        )
+    }
+
+    test_integer!(
+        test_u8 = u8,
+        test_u16 = u16,
+        test_u32 = u32,
+        test_u64 = u64,
+        test_u128 = u128,
+        test_usize = usize,
+        test_i8 = i8,
+        test_i16 = i16,
+        test_i32 = i32,
+        test_i64 = i64,
+        test_i128 = i128,
+        test_isize = isize,
+    );
+
+    #[test]
+    fn test_char() {
+        let grammar: Grammar = "expr: char ;".parse().unwrap();
+
+        let mut buf = [0u8; 64];
+        let mut rng = StdRng::seed_from_u64(42);
+
+        for _ in 0..1000 {
+            rng.fill_bytes(&mut buf);
+            let mut u = Unstructured::new(&buf);
+            let expr = grammar.expression::<String>(&mut u, None).unwrap();
+            assert_eq!(1, expr.chars().count());
+            assert!(expr.parse::<char>().is_ok());
+        }
+    }
+
+    #[test]
+    fn test_f32() {
+        let grammar: Grammar = "expr: f32 ;".parse().unwrap();
+
+        let mut buf = [0u8; 64];
+        let mut rng = StdRng::seed_from_u64(42);
+
+        for _ in 0..1000 {
+            rng.fill_bytes(&mut buf);
+            let mut u = Unstructured::new(&buf);
+            let expr = grammar.expression::<String>(&mut u, None).unwrap();
+            assert!(expr.parse::<f32>().is_ok());
+        }
+    }
+
+    #[test]
+    fn test_f64() {
+        let grammar: Grammar = "expr: f64 ;".parse().unwrap();
+
+        let mut buf = [0u8; 64];
+        let mut rng = StdRng::seed_from_u64(42);
+
+        for _ in 0..1000 {
+            rng.fill_bytes(&mut buf);
+            let mut u = Unstructured::new(&buf);
+            let expr = grammar.expression::<String>(&mut u, None).unwrap();
+            assert!(expr.parse::<f64>().is_ok());
         }
     }
 }


### PR DESCRIPTION
This PR adds the rest of the basic types that implement `Arbitrary`, e.g. `u32`, `f32`, `char`, etc.

I don't plan on adding any many more Predefined rules (such as `Vec<u8>`) since the behavior for other types can easily be re-created in using Spindle's syntax (and it also makes the parser more complicated!).

Also, I lowered `MAX_REP` to 8 for now since it 10 was making my tests run for too long. Before I publish a new version to crates.io, I will make `MAX_REP` configurable somehow, so this change is temporary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
