### PR TITLE
Add repetition range into grammar syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ let math: Grammar = r#"
     symbol : r"-|\+|\*|÷" ;
 "#.parse().unwrap();
 
-let mut u = Unstructured::new(b"poiuytasdbvcxeygrey");
-let sentence: String = math.expression(&mut u, None).unwrap();
+let mut wool = Unstructured::new(b"poiuytasdbvcxeygrey");
+let yarn: String = math.expression(&mut wool, None).unwrap();
 // (21359*39933))+13082-62216
 ```
 The state machine traversal always starts at the first rule. In the example, 
@@ -52,8 +52,8 @@ let math: Grammar = r#"
     symbol : r"-|\+|\*|÷" | String ;
 "#.parse().unwrap();
 
-let mut u = Unstructured::new(b"poiuytasdbvcxeygrey");
-let sentence: String = math.expression(&mut u, None).unwrap();
+let mut wool = Unstructured::new(b"poiuytasdbvcxeygrey");
+let yarn: String = math.expression(&mut wool, None).unwrap();
 // (44637*32200)Ѱ'x124928390-27338)
 ```
 
@@ -85,9 +85,41 @@ fuzz_target!(|expr: MathExpression| {
 });
 ```
 
-## Pre-defined Rules
-- `String` evaluates to `str::arbitrary(u)`
-- `u16` evaluates to `u16::arbitrary(u)`
+## Grammar Syntax
+**For examples see [examples](https://github.com/awslabs/spindle/tree/main/examples).**
+
+The operators of Spindle's grammar are:
+- Optional: `X?` evaluates to either `X` or nothing.
+- Repetition:
+    - `X+` evaluates to `X` 1 or more times (up to and including [`crate::MAX_REPEAT`])
+    - `X*` evaluates to `X` 0 or more times (up to and including [`crate::MAX_REPEAT`])
+    - `X{k}` evaluates to `X` exactly k times, where k is a `u32`.
+    - `X{min,max}` evaluates `X` at least `min` times and at most (including) `max` times. `min` and `max` are `u32`.
+- Or: `X | Y` evaluates to either `X` or `Y`.
+- Literal:
+    - String: `"X"` evaluates to the literal value inside the quotes, e.g. `"foo"`.
+    - Bytes: `[X]` evaluates to the literal `Vec<u8>`, e.g. `[1, 2]`.
+- Regex: `r"X"` arbitrarily evaluates the regex inside the quotes, e.g. `r"[A-Z]+"`.
+- Concat: `X Y` evaluates to `X` and then `Y`.
+- Group: `(X)` groups the expression insdie the parenthesis, e.g. `(X | Y)+`.
+- Reference: `rule : X ;` defines a rule with name "rule" with some pattern `X`. "rule" can be referenced in the same grammar, e.g. `another_rule : rule+ ;`
+- Predefined: `u16` is a pre-defined rule that evaluate to `u16::arbitrary(u)`. All pre-defined rules evaluate to `T::arbitrary(u)`. [See more](https://docs.rs/arbitrary/1.4.1/arbitrary/trait.Arbitrary.html#foreign-impls). All pre-defined rules are:
+    - String
+    - char
+    - u8
+    - u16
+    - u32
+    - u64
+    - u128
+    - usize
+    - i8
+    - i16
+    - i32
+    - i64
+    - i128
+    - isize
+    - f32
+    - f64
 
 ## Visitor
 A `Visitor` is some state that is initialized before traversal and mutated as different rules are visited during the traversal, e.g. `visit_or`. Vistors that are already implemented are `String` and `Vec<u8>` for output buffers, and `u64` for classification. 
@@ -123,9 +155,9 @@ impl Visitor for PrimeDetector {
     }
 }
 
-let mut u = arbitrary::Unstructured::new(b"qwerty");
-let (expr, any_primes): (String, PrimeDetector) = math.expression(&mut u, None).unwrap();
-let expr: String = math.expression(&mut u, None).unwrap();
+let mut wool = arbitrary::Unstructured::new(b"qwerty");
+let (expr, any_primes): (String, PrimeDetector) = math.expression(&mut wool, None).unwrap();
+let yarn: String = math.expression(&mut wool, None).unwrap();
 assert!(any_primes.0);
 ```
 
@@ -178,7 +210,7 @@ impl Visitor for MathAst {
     }
 }
 
-let mut u = arbitrary::Unstructured::new(b"494392");
+let mut wool = arbitrary::Unstructured::new(b"494392");
 // MathAst { cur_op: None, stack: [Expr(Num(13108), '*', Num(0))] }
-let tree: MathAst = math.expression(&mut u, None).unwrap();
+let yarn: MathAst = math.expression(&mut wool, None).unwrap();
 ```

--- a/examples/spindle_grammar.rs
+++ b/examples/spindle_grammar.rs
@@ -5,14 +5,14 @@ use spindle_lib::Grammar;
 fn main() {
     // a grammar that produces random grammars
     let grammar: Grammar = r#"
-        grammar   : (rule)+ ;
+        grammar   : (rule){1,5} ;
         rule      : name " : " rule_or " ;\n" ;
         rule_or : rule_concat | rule_concat " | " rule_or ;
         rule_concat : rule_repeat | rule_repeat " " rule_concat ;
         rule_repeat : terminal | terminal "?" | "(" terminal ")" ("*" | "+") ;
         terminal    : literal ;
         literal     : "\"" r"[a-z]+" "\"" ;
-        name: r"[a-z]+" ;
+        name: r"[a-z]" ;
     "#
     .parse()
     .unwrap();
@@ -23,7 +23,7 @@ fn main() {
     println!("Grammar:\n{}", sentence);
 
     let g: Grammar = sentence.parse().unwrap();
-    println!("Generated sentences:");
+    println!("\nGenerated sentences:");
     for _ in 0..10 {
         let mut buf = [0; 4096];
         let mut u = rand_u(&mut buf);

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -473,8 +473,28 @@ mod tests {
             r#"expr: "0"{3a} ;"#,
             r#"expr: "0"{-1} ;"#,
             r#"expr: "0"{} ;"#,
+            r#"expr: "0"{43250750483253} ;"#,
         ] {
-            assert!(x.parse::<Grammar>().is_err());
+            assert!(x.parse::<Grammar>().is_err(), "{}", x);
+        }
+    }
+
+    #[test]
+    fn accepts_correct_ranges() {
+        for x in [
+            r#"expr: "0"{2 ,3} ;"#,
+            r#"expr: "0"{2, 3} ;"#,
+            r#"expr: "0"{ 2,3} ;"#,
+            r#"expr: "0"{2,3 } ;"#,
+            r#"expr: "0"{ 2 , 3  } ;"#,
+            r#"expr: "0"{ 2 } ;"#,
+            r#"expr: "0"{ 2 } ; rule: "{" ; "#,
+            r#"expr: "0"{ 2 } ; rule: "}" ; "#,
+            r#"expr: "0"{ 2 } ; rule: "{ 3 }" ; "#,
+            r#"expr: "0"{ 2 } ; rule: "expr: \"0\"{ 2 } ;" ; "#,
+        ] {
+            let res = x.parse::<Grammar>();
+            assert!(res.is_ok(), "{}\n{:?}", x, res);
         }
     }
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -5,8 +5,6 @@ use crate::{ir, regex::Regex, reserved::*, Visitor};
 use arbitrary::{Arbitrary, Unstructured};
 use std::{collections::HashSet, fmt, str::FromStr};
 
-const MAX_REP: u32 = 8; // TODO, make interface for user to control this
-
 /// A state machine that produces `Arbitrary` matching expressions or byte sequences from [`Unstructured`](https://docs.rs/arbitrary/latest/arbitrary/struct.Unstructured.html).
 ///
 /// # Implementation
@@ -82,10 +80,10 @@ impl Grammar {
                     }
                     visitor.visit_optional(b);
                 }
-                Expr::Repetition(x, min_rep, i) => {
+                Expr::Repetition(x, min_rep, max_rep, i) => {
                     let mut reps = 0;
                     if self.reachable(depth, *i, 0) {
-                        u.arbitrary_loop(Some(*min_rep), Some(MAX_REP), |_| {
+                        u.arbitrary_loop(Some(*min_rep), Some(*max_rep), |_| {
                             to_write.push((x, depth));
                             reps += 1;
                             Ok(std::ops::ControlFlow::Continue(()))
@@ -230,7 +228,7 @@ enum Expr {
     Or(Vec<Expr>, usize),
     Concat(Vec<Expr>),
     Optional(Box<Expr>, usize),
-    Repetition(Box<Expr>, u32, usize),
+    Repetition(Box<Expr>, u32, u32, usize),
     Reference(usize),
     Literal(String),
     Regex(Regex),
@@ -288,18 +286,30 @@ impl Expr {
                 }
                 1u64.checked_add(child?)
             }
-            Self::Repetition(x, min_reps, i) => {
+            Self::Repetition(x, min_reps, max_reps, i) => {
                 let mut res = Some(0u64);
                 let child = x.how_many(rules, mem, reachable);
                 let child_reachable = child.map_or(true, |x| x > 0);
                 if !child_reachable {
                     reachable[*i][0] += 1;
                 }
-                if let Some(child) = child {
-                    for used_rep in *min_reps..=MAX_REP {
-                        let (sub_res, overflow) = child.overflowing_pow(used_rep);
-                        res = Self::add(res, (!overflow).then_some(sub_res));
+                match child {
+                    Some(child) if child > 1 => {
+                        for used_rep in *min_reps..=*max_reps {
+                            let (sub_res, overflow) = child.overflowing_pow(used_rep);
+                            res = Self::add(res, (!overflow).then_some(sub_res));
+                            if res.is_none() {
+                                break;
+                            }
+                        }
                     }
+                    Some(child) if child == 1 => {
+                        // e.g. min,max = 1,3
+                        // "1", "11", "111" -- 3 options
+                        let range = *max_reps as u64 - *min_reps as u64 + 1;
+                        res = Self::add(res, Some(range));
+                    }
+                    _ => (),
                 }
                 res
             }
@@ -332,7 +342,7 @@ impl fmt::Display for Expr {
             Self::Or(x, _) => fmt_w_name("or", x.iter(), f)?,
             Self::Concat(x) => fmt_w_name("concat", x.iter().rev(), f)?,
             Self::Optional(x, _) => write!(f, "option({})", x)?,
-            Self::Repetition(x, _, _) => write!(f, "repeat({})", x)?,
+            Self::Repetition(x, min, max, _) => write!(f, "repeat({}, {}, {})", x, min, max)?,
             Self::Reference(index) => write!(f, "{}", index)?,
             Self::Literal(l) => write!(f, "{:?}", l)?,
             Self::Regex(_) => write!(f, "regex")?, // TODO: no way to pretty print regex
@@ -378,10 +388,10 @@ impl Expr {
                 reachable.push(vec![0]);
                 Self::Optional(child, reachable.len() - 1)
             }
-            ir::Expr::Repetition(x, min) => {
+            ir::Expr::Repetition(x, min, max) => {
                 let child = Box::new(Self::try_new(*x, names, reachable)?);
                 reachable.push(vec![0]);
-                Self::Repetition(child, min, reachable.len() - 1)
+                Self::Repetition(child, min, max, reachable.len() - 1)
             }
             ir::Expr::Group(x) => Self::Group(Box::new(Self::try_new(*x, names, reachable)?)),
             ir::Expr::Reference(name) => match names.iter().position(|n| *n == name) {
@@ -401,6 +411,7 @@ impl Expr {
 mod tests {
     use super::*;
     use rand::{rngs::StdRng, RngCore, SeedableRng};
+    use std::hash::Hash;
 
     #[test]
     fn catches_duplicates() {
@@ -449,13 +460,34 @@ mod tests {
         }
     }
 
-    fn assert_how_many_matches_generations(grammar: &Grammar, depth: usize) {
+    #[test]
+    fn rejects_incorrect_ranges() {
+        for x in [
+            r#"expr: "0"{3,2} ;"#,
+            r#"expr: "0"{3,0} ;"#,
+            r#"expr: "0"a3,a} ;"#,
+            r#"expr: "0"{a,b} ;"#,
+            r#"expr: "0"{2,0} ;"#,
+            r#"expr: "0"{0,-1} ;"#,
+            r#"expr: "0"{-1,3} ;"#,
+            r#"expr: "0"{3a} ;"#,
+            r#"expr: "0"{-1} ;"#,
+            r#"expr: "0"{} ;"#,
+        ] {
+            assert!(x.parse::<Grammar>().is_err());
+        }
+    }
+
+    fn assert_how_many_matches_generations<T: Visitor + Hash + Eq>(
+        grammar: &Grammar,
+        depth: usize,
+    ) {
         let mut buf = [0u8; 1024];
         let num_classes = grammar
             .how_many(Some(depth))
             .expect("small number of classes") as usize;
         assert!(num_classes < 10_000);
-        let mut classes = fxhash::FxHashSet::<u64>::default();
+        let mut classes = fxhash::FxHashSet::<T>::default();
         classes.try_reserve(num_classes).unwrap();
 
         let mut rng = StdRng::seed_from_u64(42);
@@ -468,7 +500,7 @@ mod tests {
         for _ in 0..num_iterations {
             rng.fill_bytes(&mut buf);
             let mut u = Unstructured::new(&buf);
-            if let Ok(class) = grammar.expression::<u64>(&mut u, Some(depth)) {
+            if let Ok(class) = grammar.expression::<T>(&mut u, Some(depth)) {
                 classes.insert(class);
             }
         }
@@ -483,7 +515,7 @@ mod tests {
             assert_eq!(grammar.how_many(Some(max)), Some(2));
         }
         assert_eq!(grammar.how_many(None), Some(2));
-        assert_how_many_matches_generations(&grammar, 1);
+        assert_how_many_matches_generations::<u64>(&grammar, 1);
     }
 
     #[test]
@@ -497,13 +529,13 @@ mod tests {
 
         // only a depth of 1 is allowed, so "1" or "2"
         assert_eq!(grammar.how_many(Some(1)), Some(2));
-        assert_how_many_matches_generations(&grammar, 1);
+        assert_how_many_matches_generations::<u64>(&grammar, 1);
 
         // 2 + (2 * 2)
         // 2: "1" or "2"
         // 2 * 2: ("3" or "4") * ("5" or "6")
         assert_eq!(grammar.how_many(Some(2)), Some(6));
-        assert_how_many_matches_generations(&grammar, 2);
+        assert_how_many_matches_generations::<u64>(&grammar, 2);
 
         let grammar: Grammar = r#"
             expr : "1" | "2" | num? ;
@@ -512,14 +544,29 @@ mod tests {
         .parse()
         .unwrap();
         assert_eq!(grammar.how_many(Some(2)), Some(7));
-        assert_how_many_matches_generations(&grammar, 2);
+        assert_how_many_matches_generations::<u64>(&grammar, 2);
         assert_eq!(grammar.how_many(None), Some(7));
     }
 
     #[test]
-    fn how_many_reps() {
+    fn how_many_static_reps() {
         let grammar: Grammar = r#"
-            expr : num* ;
+            expr : num{6} ;
+            num  : "0" | "1" ;
+        "#
+        .parse()
+        .unwrap();
+
+        // 2 choices, exactly 6 times... 2^6 = 64
+        assert_eq!(grammar.how_many(Some(2)), Some(64));
+        assert_eq!(grammar.how_many(None), Some(64));
+        assert_how_many_matches_generations::<u64>(&grammar, 2);
+    }
+
+    #[test]
+    fn how_many_bounded_reps() {
+        let grammar: Grammar = r#"
+            expr : num{0,6} ;
             num  : "0" | "1" ;
         "#
         .parse()
@@ -530,24 +577,61 @@ mod tests {
         // 2 reps: 2^2
         // 3 reps: 2^3
         // ...
-        assert_eq!(grammar.how_many(Some(2)), Some(511));
-        assert_eq!(grammar.how_many(None), Some(511));
+        assert_eq!(grammar.how_many(Some(2)), Some(127));
+        assert_eq!(grammar.how_many(None), Some(127));
+        assert_how_many_matches_generations::<u64>(&grammar, 2);
+    }
+
+    #[test]
+    fn how_many_inf_reps() {
+        let grammar: Grammar = r#"
+            expr : num* ;
+            num  : "0" | "1" ;
+        "#
+        .parse()
+        .unwrap();
+
+        assert_eq!(grammar.how_many(Some(2)), None);
+        assert_eq!(grammar.how_many(None), None);
+
+        let grammar: Grammar = r#"
+            expr : num* ;
+            num  : "0" ;
+        "#
+        .parse()
+        .unwrap();
+
+        assert_eq!(
+            grammar.how_many(Some(2)),
+            Some(crate::MAX_REPEAT as u64 + 1)
+        );
+        assert_eq!(grammar.how_many(None), Some(crate::MAX_REPEAT as u64 + 1));
+
+        let grammar: Grammar = r#"
+            expr : num* ;
+            num  : "0" | r"[a-z]{2,3}" ;
+        "#
+        .parse()
+        .unwrap();
+
+        assert_eq!(grammar.how_many(Some(2)), None);
+        assert_eq!(grammar.how_many(None), None);
     }
 
     #[test]
     fn how_many_choice() {
         let grammar: Grammar = r#"expr : "1"? ;"#.parse().unwrap();
         assert_eq!(grammar.how_many(Some(2)), Some(2));
-        assert_how_many_matches_generations(&grammar, 2);
+        assert_how_many_matches_generations::<u64>(&grammar, 2);
 
         let grammar: Grammar = r#"expr : ("1" | "2" )? ;"#.parse().unwrap();
         assert_eq!(grammar.how_many(Some(2)), Some(3));
-        assert_how_many_matches_generations(&grammar, 2);
+        assert_how_many_matches_generations::<u64>(&grammar, 2);
 
         // "1", "2", "", or "" (outer)
         let grammar: Grammar = r#"expr : ("1" | "2"? )? ;"#.parse().unwrap();
         assert_eq!(grammar.how_many(Some(2)), Some(4));
-        assert_how_many_matches_generations(&grammar, 2);
+        assert_how_many_matches_generations::<u64>(&grammar, 2);
         assert_eq!(grammar.how_many(None), Some(4));
     }
 
@@ -561,13 +645,13 @@ mod tests {
         .unwrap();
 
         assert_eq!(grammar.how_many(Some(1)), Some(1));
-        assert_how_many_matches_generations(&grammar, 1);
+        assert_how_many_matches_generations::<u64>(&grammar, 1);
 
         // a singular number
         // two numbers with 4 possible operators
         // 1 + 4
         assert_eq!(grammar.how_many(Some(2)), Some(5));
-        assert_how_many_matches_generations(&grammar, 2);
+        assert_how_many_matches_generations::<u64>(&grammar, 2);
 
         // combinations are:
         // 1 singular number
@@ -575,18 +659,18 @@ mod tests {
         // * 4 possible symbols
         // * 5 possible expressions on the right
         assert_eq!(grammar.how_many(Some(3)), Some(101));
-        assert_how_many_matches_generations(&grammar, 3);
+        assert_how_many_matches_generations::<u64>(&grammar, 3);
         assert_eq!(grammar.how_many(None), None);
     }
 
     #[test]
     fn how_many_with_prefined() {
         let grammar: Grammar = r#"
-            one : "1" | "2" | (u16 | String)? | u16? | (u16 | String)* ;
+            one : "1" | "2" | (u16 | String)? | u16? | (u16 | String){6} ;
         "#
         .parse()
         .unwrap();
-        assert_how_many_matches_generations(&grammar, 2);
+        assert_how_many_matches_generations::<u64>(&grammar, 2);
     }
 
     #[test]
@@ -601,15 +685,15 @@ mod tests {
         .unwrap();
 
         assert_eq!(grammar.how_many(Some(1)), Some(0));
-        assert_how_many_matches_generations(&grammar, 1);
+        assert_how_many_matches_generations::<u64>(&grammar, 1);
         // only "1" and "2" are reachable, `nested` is a reference
         // and needs one more depth!
         assert_eq!(grammar.how_many(Some(2)), Some(2));
-        assert_how_many_matches_generations(&grammar, 2);
+        assert_how_many_matches_generations::<u64>(&grammar, 2);
 
         // 3 + 2 * 4 * 2
         assert_eq!(grammar.how_many(Some(3)), Some(19));
-        assert_how_many_matches_generations(&grammar, 3);
+        assert_how_many_matches_generations::<u64>(&grammar, 3);
 
         // This grammar is infinitely recursive
         assert_eq!(grammar.how_many(None), None);
@@ -626,7 +710,8 @@ mod tests {
         .unwrap();
         assert_eq!(grammar.how_many(Some(10)), Some(3));
         for depth in 0..=3 {
-            assert_how_many_matches_generations(&grammar, depth);
+            assert_how_many_matches_generations::<u64>(&grammar, depth);
+            assert_how_many_matches_generations::<String>(&grammar, depth);
         }
     }
 
@@ -655,7 +740,8 @@ mod tests {
         for depth in 1..=4 {
             let valid = success_count(&grammar, depth, 100);
             assert_eq!(valid, 100);
-            assert_how_many_matches_generations(&grammar, depth);
+            assert_how_many_matches_generations::<u64>(&grammar, depth);
+            assert_how_many_matches_generations::<String>(&grammar, depth);
         }
     }
 
@@ -670,7 +756,8 @@ mod tests {
         for depth in 1..=4 {
             let valid = success_count(&grammar, depth, 100);
             assert_eq!(valid, 100);
-            assert_how_many_matches_generations(&grammar, depth);
+            assert_how_many_matches_generations::<u64>(&grammar, depth);
+            assert_how_many_matches_generations::<String>(&grammar, depth);
         }
     }
 
@@ -685,7 +772,8 @@ mod tests {
         for depth in 1..=4 {
             let valid = success_count(&grammar, depth, 100);
             assert_eq!(valid, 100);
-            assert_how_many_matches_generations(&grammar, depth);
+            assert_how_many_matches_generations::<u64>(&grammar, depth);
+            assert_how_many_matches_generations::<String>(&grammar, depth);
         }
     }
 
@@ -702,30 +790,34 @@ mod tests {
         for depth in 1..=4 {
             let valid = success_count(&grammar, depth, 100);
             assert_eq!(valid, 100);
-            assert_how_many_matches_generations(&grammar, depth);
+            assert_how_many_matches_generations::<u64>(&grammar, depth);
+            assert_how_many_matches_generations::<String>(&grammar, depth);
         }
     }
 
     #[test]
     fn avoid_long_expr_rep_0_or_more() {
         let grammar: Grammar = r#"
-            one : "1" | two* ;
+            one : "1" | two{4} ;
             two : "2";
         "#
         .parse()
         .unwrap();
 
+        assert_eq!(grammar.how_many(Some(1)), Some(1));
+
         for depth in 1..=4 {
             let valid = success_count(&grammar, depth, 100);
             assert_eq!(valid, 100);
-            assert_how_many_matches_generations(&grammar, depth);
+            assert_how_many_matches_generations::<u64>(&grammar, depth);
+            assert_how_many_matches_generations::<String>(&grammar, depth);
         }
     }
 
     #[test]
     fn avoid_long_expr_rep_1_or_more() {
         let grammar: Grammar = r#"
-            one : "1" | two+ ;
+            one : "1" | two{1,3} ;
             two : "2";
         "#
         .parse()
@@ -734,7 +826,8 @@ mod tests {
         for depth in 1..=4 {
             let valid = success_count(&grammar, depth, 100);
             assert_eq!(valid, 100);
-            assert_how_many_matches_generations(&grammar, depth);
+            assert_how_many_matches_generations::<u64>(&grammar, depth);
+            assert_how_many_matches_generations::<String>(&grammar, depth);
         }
     }
 
@@ -751,11 +844,13 @@ mod tests {
         for depth in 0..=2 {
             let valid = success_count(&grammar, depth, 100);
             assert_eq!(valid, 0);
-            assert_how_many_matches_generations(&grammar, depth);
+            assert_how_many_matches_generations::<u64>(&grammar, depth);
+            assert_how_many_matches_generations::<String>(&grammar, depth);
         }
         let valid = success_count(&grammar, 3, 100);
         assert_eq!(valid, 100);
-        assert_how_many_matches_generations(&grammar, 3);
+        assert_how_many_matches_generations::<u64>(&grammar, 3);
+        assert_how_many_matches_generations::<String>(&grammar, 3);
     }
 
     #[test]
@@ -772,15 +867,15 @@ mod tests {
         for depth in 1..=8 {
             let valid = success_count(&grammar, depth, 100);
             assert_eq!(valid, 100);
-            assert_how_many_matches_generations(&grammar, depth);
+            assert_how_many_matches_generations::<u64>(&grammar, depth);
         }
     }
 
     #[test]
     fn avoid_mixed_branches() {
         let grammar: Grammar = r#"
-            expr : "qwerty"* | "4" | (two)? ;
-            two : "5"* | three | three four? ;
+            expr : "qwerty"{2,4} | "4" | (two)? ;
+            two : "5"{3} | three | three four? ;
             three : two | three ;
             four  : "4" ;
         "#
@@ -788,7 +883,7 @@ mod tests {
         .unwrap();
 
         for depth in 1..=6 {
-            assert_how_many_matches_generations(&grammar, depth);
+            assert_how_many_matches_generations::<u64>(&grammar, depth);
         }
 
         for depth in 1..=30 {

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -52,7 +52,7 @@ pub grammar bnf() for str {
         / g:expression() _ "{" _ n:$(['0'..='9']+) _ "}" {?
             n.parse().map_or(Err("u32"), |reps| Ok(Expr::Repetition(Box::new(g), reps, reps)))
         }
-        / g:expression() _ "{" _ n1:$(['0'..='9']+) _ "," _ n2:$(['0'..='9']+) "}" {?
+        / g:expression() _ "{" _ n1:$(['0'..='9']+) _ "," _ n2:$(['0'..='9']+) _ "}" {?
             let min_reps = n1.parse().or(Err("u32"))?;
             let max_reps = n2.parse().or(Err("u32"))?;
             match min_reps < max_reps {

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -2,6 +2,11 @@
 
 use peg::parser;
 
+/// The maxium repititions in `+` and `*` rules.
+/// This can be overriden with explicit range rules,
+/// e.g. `"3"{0,2345678}` repeats up to 2345678 `"3"`s.
+pub const MAX_REPEAT: u32 = 255;
+
 parser! {
 /// This parser is not meant to efficient, since parsing the grammar is not meant to be
 /// on the hot path (unlike generating expressions).
@@ -42,8 +47,20 @@ pub grammar bnf() for str {
         = l:(branch_inner() **<2,64> "|") { Expr::Or(l) }
 
     rule rep() -> Expr
-        = g:expression() _ "*" { Expr::Repetition(Box::new(g), 0) }
-        / g:expression() _ "+" { Expr::Repetition(Box::new(g), 1) }
+        = g:expression() _ "*" { Expr::Repetition(Box::new(g), 0, MAX_REPEAT) }
+        / g:expression() _ "+" { Expr::Repetition(Box::new(g), 1, MAX_REPEAT) }
+        / g:expression() _ "{" _ n:$(['0'..='9']+) _ "}" {?
+            n.parse().map_or(Err("u32"), |reps| Ok(Expr::Repetition(Box::new(g), reps, reps)))
+        }
+        / g:expression() _ "{" _ n1:$(['0'..='9']+) _ "," _ n2:$(['0'..='9']+) "}" {?
+            let min_reps = n1.parse().or(Err("u32"))?;
+            let max_reps = n2.parse().or(Err("u32"))?;
+            match min_reps < max_reps {
+                true => Ok(Expr::Repetition(Box::new(g), min_reps, max_reps)),
+                false => Err("Min repetitions cannot be larger than max repetitions"),
+            }
+
+        }
 
     rule choice() -> Expr
         = g:expression() _ "?" { Expr::Optional(Box::new(g)) }
@@ -108,7 +125,7 @@ pub enum Expr {
     Or(Vec<Expr>),
     Concat(Vec<Expr>),
     Optional(Box<Expr>),
-    Repetition(Box<Expr>, u32),
+    Repetition(Box<Expr>, u32, u32),
     Reference(String),
     Literal(String),
     Regex(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,5 @@ mod visitor;
 
 pub use error::Error;
 pub use grammar::Grammar;
+pub use ir::MAX_REPEAT;
 pub use visitor::Visitor;


### PR DESCRIPTION
This PR adds the ability for users to specify the minimum or maximum number of repetitions of an expression.

Repetition:
- (old feature) `X+` evaluates to `X` 1 or more times (up to and including [crate::MAX_REPEAT](https://github.com/awslabs/spindle/pull/constant.MAX_REPEAT.html))
- (old feature) `X*` evaluates to `X` 0 or more times (up to and including [crate::MAX_REPEAT](https://github.com/awslabs/spindle/pull/constant.MAX_REPEAT.html))
- `X{k}` evaluates to `X` exactly k times, where k is a u32.
- `X{min,max}` evaluates `X` at least min times and at most (including) max times. min and max are u32.

for `*` and `+` the hardcoded maximum is 255--it's there because if it wasn't then grammars using those might generate *a lot* of data. If users wan't more control, they can manually override it to their heart's desire: e.g. `{0,12345}`.

Building the min and max repeat into the syntax is way cleaner and more flexible than a dorky `max_repeat` parameter in the `expression` call. It also does not complicate calculating `how_many`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
