### PR TITLE
Add rule name to visit_reference and clean up docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spindle-lib"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.70.0"
 description = "Simple and efficient expression and byte sequence generator for fuzz testing."
@@ -8,7 +8,8 @@ license = "Apache-2.0"
 homepage = "https://github.com/awslabs/spindle"
 repository = "https://github.com/awslabs/spindle"
 readme = "README.md"
-keywords = ["arbitrary", "testing", "fuzz", "parsing", "serialization"]
+categories = ["parsing", "encoding", "algorithms", "development-tools::testing"]
+keywords = ["arbitrary", "grammar", "fuzzing", "parsing", "serialization"]
 
 [dependencies]
 arbitrary = "1.4.1"

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ let yarn: String = math.expression(&mut wool, None).unwrap();
 The state machine traversal always starts at the first rule. In the example, 
 - `expr` is the first rule and evaluates to either `u16`, `paren`, or the concatenation of `expr` and `symbol` and `expr`.
 - `;` delimits different rules.
-- `u16` is a pre-defined data types that directly evaluates to `u16::arbitrary(u)`.
-- `paren` evaluates to the concatenation of the literal `"("`, `expr`, `symbol`, `expr` and, `")"`.
-- `symbol` evaluates to the an arbitrary string matching the regex `-|\+|\*|÷`.
+- `u16` is a pre-defined rule that directly evaluates to `u16::arbitrary(u)`.
+- `paren` evaluates to the concatenation of the literal `"("`, `expr`, `symbol`, `expr`, and `")"`.
+- `symbol` evaluates to any arbitrary string that matches the regex `-|\+|\*|÷`.
 
 ### Semi-Correct Expression
 This grammar is similar to the well formed math expression grammar, but sometimes includes an extra closing parenthesis and/or an arbitrary symbol.

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ use std::sync::LazyLock;
 static GRAMMAR: LazyLock<Grammar> = LazyLock::new(|| {
     r#"
         expr   : u16 | paren | expr symbol expr ;
-        paren  : "(" expr symbol expr ")" ;
-        symbol : r"-|\+|\*|÷" ;
+        paren  : "(" expr symbol expr ")" ")"? ;
+        symbol : r"-|\+|\*|÷" | String ;
     "#.parse().unwrap()
 });
 
@@ -76,7 +76,7 @@ struct MathExpression(String);
 
 impl<'a> Arbitrary<'a> for MathExpression {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        Ok(Self(GRAMMAR.expression(u, None)?.0))
+        Ok(Self(GRAMMAR.expression(u, None)?))
     }
 }
 
@@ -84,47 +84,43 @@ fuzz_target!(|expr: MathExpression| {
     // ... my_parser(expr);
 });
 ```
+#### Samples
+```text
+6705d81051237=
+♣69382149-12901+8851÷50*3993043534
+(8198942155÷60177552446447)
+(586643-96)*036074789
+(8÷68){K2628
+(5798))
+(0868430}ݾ▼73)
+0135259
+(930-6*9502)
+5045620÷91599
+```
 
 ## Grammar Syntax
 **For examples see [examples](https://github.com/awslabs/spindle/tree/main/examples).**
 
-The operators of Spindle's grammar are:
-- Optional: `X?` evaluates to either `X` or nothing.
-- Repetition:
-    - `X+` evaluates to `X` 1 or more times (up to and including [`crate::MAX_REPEAT`])
-    - `X*` evaluates to `X` 0 or more times (up to and including [`crate::MAX_REPEAT`])
-    - `X{k}` evaluates to `X` exactly k times, where k is a `u32`.
-    - `X{min,max}` evaluates `X` at least `min` times and at most (including) `max` times. `min` and `max` are `u32`.
-- Or: `X | Y` evaluates to either `X` or `Y`.
-- Literal:
-    - String: `"X"` evaluates to the literal value inside the quotes, e.g. `"foo"`.
-    - Bytes: `[X]` evaluates to the literal `Vec<u8>`, e.g. `[1, 2]`.
-- Regex: `r"X"` arbitrarily evaluates the regex inside the quotes, e.g. `r"[A-Z]+"`.
-- Concat: `X Y` evaluates to `X` and then `Y`.
-- Group: `(X)` groups the expression insdie the parenthesis, e.g. `(X | Y)+`.
-- Reference: `rule : X ;` defines a rule with name "rule" with some pattern `X`. "rule" can be referenced in the same grammar, e.g. `another_rule : rule+ ;`
-- Predefined: `u16` is a pre-defined rule that evaluate to `u16::arbitrary(u)`. All pre-defined rules evaluate to `T::arbitrary(u)`. [See more](https://docs.rs/arbitrary/1.4.1/arbitrary/trait.Arbitrary.html#foreign-impls). All pre-defined rules are:
-    - String
-    - char
-    - u8
-    - u16
-    - u32
-    - u64
-    - u128
-    - usize
-    - i8
-    - i16
-    - i32
-    - i64
-    - i128
-    - isize
-    - f32
-    - f64
+| Syntax      | Description |
+| ----------- | ----------- |
+| `rule : X ;` | Defines a rule with name "rule" with some pattern `X`. "rule" can be referenced in the same grammar, e.g. `another_rule : rule+ ;` |
+| `X?`         | Evaluates to either `X` or nothing. |
+| `X+`         | Evaluates to `X` 1 or more times (up to and including [`crate::MAX_REPEAT`]) |
+| `X*`         | Evaluates to `X` 0 or more times (up to and including [`crate::MAX_REPEAT`]) |
+| `X{k}`       | Evaluates to `X` exactly `k` times, where `k` is a `u32`. |
+| `X{min,max}` | Evaluates `X` at least `min` times and at most (including) `max` times. `min` and `max` are `u32`. |
+| `X \| Y`     | Evaluates to either `X` or `Y`. |
+| `"X"`        | Literal value inside the quotes, e.g. `"foo"` |
+| `[X]`        | Literal `Vec<u8>`, e.g. `[1, 2]`. |
+| `r"X"`       | Arbitrarily evaluates the regex inside the quotes, e.g. `r"[A-Z]+"`. |
+| `X Y`        | Evaluates to `X` and then `Y`. |
+| `(X)`        | Groups the expression inside the parenthesis, e.g. `(X \| Y)+`. |
+| `u16`, `String`, etc | A pre-defined type that evaluates to `T::arbitrary(u)`. [See more](https://docs.rs/arbitrary/1.4.1/arbitrary/trait.Arbitrary.html#foreign-impls). Supported pre-defined rules are `String`, `char`, `f32`, `f64`, and signed+unsigned integer types. |
 
 ## Visitor
-A `Visitor` is some state that is initialized before traversal and mutated as different rules are visited during the traversal, e.g. `visit_or`. Vistors that are already implemented are `String` and `Vec<u8>` for output buffers, and `u64` for classification. 
+A [`Visitor`] is state that is initialized before traversal and mutated as different rules are visited during the traversal, e.g. `visit_or`. Visitors that are already implemented are `String` and `Vec<u8>` for output buffers, and `u64` for classification.
 
-Users can use their own implementation of `Visitor`, for example if they want to 
+Users can implement their own `Visitor` to
 - use a different output buffer
 - use a different classification
 - gather data

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 Spindle is a simple and efficient expression and byte sequence generator to aid fuzz testing parsers and de-serializers. Spindle spins raw, untyped byte buffers into structured data.
 
 ## Overview
-Spindle's syntax, similar to [Extended Backus–Naur form](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form), lets users define the structure of generated data. This syntax compiles to `Grammar`, a state machine that can be arbitrarily traversed to produce structure-aware, matching expressions.
+Spindle's syntax lets users define the structure of generated data. This syntax compiles to `Grammar`, a state machine that can be arbitrarily traversed to produce structure-aware, matching expressions.
 
 Spindle works with fuzzers such as [cargo-fuzz](https://crates.io/crates/cargo-fuzz) or [AFL](https://crates.io/crates/afl) because it is an extension of [arbitrary](https://crates.io/crates/arbitrary); the traversal of the state machine is deterministically dependent on [`Unstructured`](https://docs.rs/arbitrary/latest/arbitrary/struct.Unstructured.html).
 
-Spindle is particularily useful for generating semi-correct and interesting inputs that attack edge cases of parsers and de-serializers, such as mixing familar tokens in incorrect places or sprinkling in Unicode characters.
+Spindle is particularly useful for generating semi-correct and interesting inputs that attack edge cases of parsers and de-serializers, such as mixing familiar tokens in incorrect places or sprinkling in Unicode characters.
 
 Spindle is developed and leveraged by AWS to fuzz test the parsers and de-serializers in their backend systems.
 
@@ -115,7 +115,7 @@ fuzz_target!(|expr: MathExpression| {
 | `r"X"`       | Arbitrarily evaluates the regex inside the quotes, e.g. `r"[A-Z]+"`. |
 | `X Y`        | Evaluates to `X` and then `Y`. |
 | `(X)`        | Groups the expression inside the parenthesis, e.g. `(X \| Y)+`. |
-| `u16`, `String`, etc | A pre-defined type that evaluates to `T::arbitrary(u)`. [See more](https://docs.rs/arbitrary/1.4.1/arbitrary/trait.Arbitrary.html#foreign-impls). Supported pre-defined rules are `String`, `char`, `f32`, `f64`, and signed+unsigned integer types. |
+| `u16`, `String`, etc | A pre-defined type that evaluates to `T::arbitrary(u)`. [See more](https://docs.rs/arbitrary/1.4.1/arbitrary/trait.Arbitrary.html#foreign-impls). Supported pre-defined rules are `String`, `char`, `f32`, `f64`, and signed + unsigned integer types. |
 
 ## Visitor
 A [`Visitor`] is state that is initialized before traversal and mutated as different rules are visited during the traversal, e.g. `visit_or`. Visitors that are already implemented are `String` and `Vec<u8>` for output buffers, and `u64` for classification.

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -2,7 +2,7 @@ use itoa::Buffer as itoaBuffer;
 use ryu::Buffer as ryuBuffer;
 use std::str;
 
-/// Defines state that is built during `Grammar::expression`.
+/// Defines state that is built during [`crate::Grammar::expression`].
 ///
 /// This is implemented for
 /// - `String` to produce string expressions
@@ -11,35 +11,62 @@ use std::str;
 ///
 /// You can implement this yourself, for example if you want to implement equivalence classes that
 /// - ignore order
-/// - ignore certain rules
+/// - ignore certain paths or transitions
 /// - are more accurate
-/// - care about characterics of the arbitrary data, such as if a string is ascii or not.  
+/// - care about characterics of the arbitrary data, such as if a string is ascii or not.
+/// Or implement a visitor to build some structured state, such as a tree a collection of generated data.
 pub trait Visitor {
+    /// Instiates the visitor before traversal.
     fn new() -> Self;
+    /// Visits the `X | Y` branch in the grammar and provides the `index`th path that was taken.
     fn visit_or(&mut self, _index: usize) {}
+    /// Visits the `X Y` operation.
     fn visit_concat(&mut self) {}
+    /// Visits `X?` and provides whether or not `X` will be evaluated.
     fn visit_optional(&mut self, _was_chosen: bool) {}
+    /// Visits `X*`, `X+`, `X{k}`, or `X{min,max}` and provides how many repetitions were arbitrarily selected.
     fn visit_repetition(&mut self, _reps: usize) {}
-    fn visit_reference(&mut self, _index: usize) {}
+    /// Visits a use/reference of a defined rule and provides the rule name and index/id.
+    fn visit_reference(&mut self, _name: &str, _index: usize) {}
+    /// Visits the literal `str`.
     fn visit_literal(&mut self, _s: &str) {}
+    /// Visits the literal `&[u8]`.
     fn visit_bytes(&mut self, _val: &[u8]) {}
-    fn visit_regex(&mut self, _val: &[u8]) {}
+    /// Visits regex and provides the arbitrary regex that was generated.
+    fn visit_regex(&mut self, _generated: &[u8]) {}
+    /// Visits the `(X)` group.
     fn visit_group(&mut self) {}
+    /// Visits `String` pre-defined rule and provides the generated arbitrary `str`.
     fn visit_str(&mut self, _s: &str) {}
+    /// Visits `char` pre-defined rule and provides the generated arbitrary `char`.
     fn visit_char(&mut self, _c: char) {}
+    /// Visits `f32` pre-defined rule and provides the generated arbitrary `f32`.
     fn visit_f32(&mut self, _f: f32) {}
+    /// Visits `f64` pre-defined rule and provides the generated arbitrary `f64`.
     fn visit_f64(&mut self, _f: f64) {}
+    /// Visits `u8` pre-defined rule and provides the generated arbitrary `u8`.
     fn visit_u8(&mut self, _num: u8) {}
+    /// Visits `u16` pre-defined rule and provides the generated arbitrary `u16`.
     fn visit_u16(&mut self, _num: u16) {}
+    /// Visits `u32` pre-defined rule and provides the generated arbitrary `u32`.
     fn visit_u32(&mut self, _num: u32) {}
+    /// Visits `u64` pre-defined rule and provides the generated arbitrary `u64`.
     fn visit_u64(&mut self, _num: u64) {}
+    /// Visits `u128` pre-defined rule and provides the generated arbitrary `u128`.
     fn visit_u128(&mut self, _num: u128) {}
+    /// Visits `usize` pre-defined rule and provides the generated arbitrary `usize`.
     fn visit_usize(&mut self, _num: usize) {}
+    /// Visits `i8` pre-defined rule and provides the generated arbitrary `i8`.
     fn visit_i8(&mut self, _num: i8) {}
+    /// Visits `i16` pre-defined rule and provides the generated arbitrary `i16`.
     fn visit_i16(&mut self, _num: i16) {}
+    /// Visits `i32` pre-defined rule and provides the generated arbitrary `i32`.
     fn visit_i32(&mut self, _num: i32) {}
+    /// Visits `i64` pre-defined rule and provides the generated arbitrary `i64`.
     fn visit_i64(&mut self, _num: i64) {}
+    /// Visits `i128` pre-defined rule and provides the generated arbitrary `i128`.
     fn visit_i128(&mut self, _num: i128) {}
+    /// Visits `isize` pre-defined rule and provides the generated arbitrary `isize`.
     fn visit_isize(&mut self, _num: isize) {}
 }
 
@@ -170,7 +197,7 @@ impl Visitor for u64 {
     fn visit_optional(&mut self, was_chosen: bool) {
         id_hash(self, fxhash::hash64(&(2, was_chosen as u64)))
     }
-    fn visit_reference(&mut self, index: usize) {
+    fn visit_reference(&mut self, _: &str, index: usize) {
         id_hash(self, fxhash::hash64(&(3, index as u64)))
     }
     fn visit_repetition(&mut self, reps: usize) {
@@ -224,9 +251,9 @@ macro_rules! impl_visitor_tuple {
                 let ($(ref mut $name,)+) = *self;
                 $($name.visit_repetition(reps);)+
             }
-            fn visit_reference(&mut self, index: usize) {
+            fn visit_reference(&mut self, name: &str, index: usize) {
                 let ($(ref mut $name,)+) = *self;
-                $($name.visit_reference(index);)+
+                $($name.visit_reference(name, index);)+
             }
             fn visit_literal(&mut self, val: &str) {
                 let ($(ref mut $name,)+) = *self;


### PR DESCRIPTION
This PR internally tracks the rule names and provides them in `visit_reference` (along with the rule's index/id). It moves the version to 0.3.0 since this is a breaking change.

It also cleans up the docs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
