### PR TITLE
Add support for probabilistic grammars

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ let mut wool = Unstructured::new(b"poiuytasdbvcxeygrey");
 let yarn: String = math.expression(&mut wool, None).unwrap();
 // (21359*39933))+13082-62216
 ```
-The state machine traversal always starts at the first rule. In the example, 
+The state machine traversal always starts at the first rule. In the example,
 - `expr` is the first rule and evaluates to either `u16`, `paren`, or the concatenation of `expr` and `symbol` and `expr`.
 - `;` delimits different rules.
 - `u16` is a pre-defined rule that directly evaluates to `u16::arbitrary(u)`.
@@ -115,6 +115,7 @@ fuzz_target!(|expr: MathExpression| {
 | `r"X"`       | Arbitrarily evaluates the regex inside the quotes, e.g. `r"[A-Z]+"`. |
 | `X Y`        | Evaluates to `X` and then `Y`. |
 | `(X)`        | Groups the expression inside the parenthesis, e.g. `(X \| Y)+`. |
+| `X @ w \| Y @ v` | Evaluates to either `X` or `Y` based off probabilities given by weights `w` and `v` respectively, where `w` and `v` are `u16`.
 | `u16`, `String`, etc | A pre-defined type that evaluates to `T::arbitrary(u)`. [See more](https://docs.rs/arbitrary/1.4.1/arbitrary/trait.Arbitrary.html#foreign-impls). Supported pre-defined rules are `String`, `char`, `f32`, `f64`, and signed + unsigned integer types. |
 
 ## Visitor

--- a/examples/probabilistic_math.rs
+++ b/examples/probabilistic_math.rs
@@ -6,9 +6,9 @@ use crate::common::rand_u;
 fn main() {
     // this grammar will generate more numbers than expressions
     let grammar: Grammar = r#"
-        expr   : num                     90 
-               | paren                   5
-               | expr symbol expr        5  ;
+        expr   : num                   @ 90
+               | paren                 @ 5
+               | expr symbol expr      @ 5  ;
         paren  : "(" expr symbol expr ")"   ;
         symbol : r"-|\+|\*|÷"               ;
         num    : r"[0-9]+"                  ;

--- a/examples/probabilistic_math.rs
+++ b/examples/probabilistic_math.rs
@@ -1,0 +1,25 @@
+mod common;
+use spindle_lib::Grammar;
+
+use crate::common::rand_u;
+
+fn main() {
+    // this grammar will generate more numbers than expressions
+    let grammar: Grammar = r#"
+        expr   : num                     90 
+               | paren                   5
+               | expr symbol expr        5  ;
+        paren  : "(" expr symbol expr ")"   ;
+        symbol : r"-|\+|\*|÷"               ;
+        num    : r"[0-9]+"                  ;
+    "#
+    .parse()
+    .unwrap();
+
+    let mut buf = [0; 4096];
+    let mut u = rand_u(&mut buf);
+    for _ in 0..100 {
+        let sentence: String = grammar.expression(&mut u, Some(10)).unwrap();
+        println!("{}\n", sentence);
+    }
+}

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -980,7 +980,7 @@ mod probabilistic_grammar {
     #[test]
     fn simple_parse_weighted() {
         let grammar: Grammar = r#"
-            expr   : num                      1 
+            expr   : num                      1
                    | paren                    2
                    | expr symbol expr         3 ;
             paren  : "(" expr symbol expr ")" 4 ;
@@ -1049,7 +1049,7 @@ mod probabilistic_grammar {
     fn allow_leading_zero_weight() {
         // Allow leading zeros to align with Rust's integer parsing behavior
         let _grammar2: Grammar = r#"
-            expr   : num                      1 
+            expr   : num                      1
                    | paren                    0002000
                    | expr symbol expr         3 ;
             paren  : "(" expr symbol expr ")" 4 ;
@@ -1063,7 +1063,7 @@ mod probabilistic_grammar {
     #[test]
     fn zero_weights_not_included() {
         let grammar1: Grammar = r#"
-            expr   : num                      1 
+            expr   : num                      1
                    | paren                    0
                    | expr symbol expr         3 ;
             paren  : "(" expr symbol expr ")" 4 ;
@@ -1139,7 +1139,7 @@ mod probabilistic_grammar {
         // if part of a rule has assigned weights but another doesn't
         let grammar1: Result<Grammar, _> = r#"
             rule1 : branch1         12
-                  | branch1 branch1 
+                  | branch1 branch1
                   | "a"             45
                   | branch1 "a"     881 ;
             branch1 : "b"           1   ;
@@ -1187,7 +1187,10 @@ mod probabilistic_grammar {
 
         assert_eq!(grammar.how_many(None), prob_grammar.how_many(None));
         for depth in 1..=100 {
-            assert_eq!(grammar.how_many(Some(depth)), prob_grammar.how_many(Some(depth)));
+            assert_eq!(
+                grammar.how_many(Some(depth)),
+                prob_grammar.how_many(Some(depth))
+            );
         }
     }
 
@@ -1219,7 +1222,32 @@ mod probabilistic_grammar {
 
         assert_eq!(grammar.how_many(None), prob_grammar.how_many(None));
         for depth in 1..=100 {
-            assert_eq!(grammar.how_many(Some(depth)), prob_grammar.how_many(Some(depth)));
+            assert_eq!(
+                grammar.how_many(Some(depth)),
+                prob_grammar.how_many(Some(depth))
+            );
+        }
+    }
+
+    #[test]
+    fn reject_non_u16_weight() {
+        let grammar: Result<Grammar, _> = r#"
+            rule1 : "a" 65535 ;
+        "#
+        .parse();
+        assert!(grammar.is_ok());
+
+        let grammar: Result<Grammar, _> = r#"
+            rule1 : "a" 65536 ;
+        "#
+        .parse();
+        assert!(grammar.is_err());
+        if let Err(e) = grammar {
+            assert!(
+                e.to_string().contains("can't parse weight to u16"),
+                "Error string: {}",
+                e
+            );
         }
     }
 }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -980,12 +980,12 @@ mod probabilistic_grammar {
     #[test]
     fn simple_parse_weighted() {
         let grammar: Grammar = r#"
-            expr   : num                      1
-                   | paren                    2
-                   | expr symbol expr         3 ;
-            paren  : "(" expr symbol expr ")" 4 ;
-            symbol : r"-|\+|\*|÷"             5 ;
-            num    : r"[0-9]+"                6 ;
+            expr   : num                      @1
+                   | paren                    @ 2
+                   | expr symbol expr         @     3 ;
+            paren  : "(" expr symbol expr ")"@ 4 ;
+            symbol : r"-|\+|\*|÷"@5;
+            num    : r"[0-9]+"                @ 6 ;
         "#
         .parse()
         .unwrap();
@@ -1049,12 +1049,12 @@ mod probabilistic_grammar {
     fn allow_leading_zero_weight() {
         // Allow leading zeros to align with Rust's integer parsing behavior
         let _grammar2: Grammar = r#"
-            expr   : num                      1
-                   | paren                    0002000
-                   | expr symbol expr         3 ;
-            paren  : "(" expr symbol expr ")" 4 ;
-            symbol : r"-|\+|\*|÷"             5 ;
-            num    : r"[0-9]+"                6 ;
+            expr   : num                      @ 1
+                   | paren                    @ 0002000
+                   | expr symbol expr         @ 3 ;
+            paren  : "(" expr symbol expr ")" @ 4 ;
+            symbol : r"-|\+|\*|÷"             @ 5 ;
+            num    : r"[0-9]+"                @ 6 ;
         "#
         .parse()
         .unwrap();
@@ -1063,12 +1063,12 @@ mod probabilistic_grammar {
     #[test]
     fn zero_weights_not_included() {
         let grammar1: Grammar = r#"
-            expr   : num                      1
-                   | paren                    0
-                   | expr symbol expr         3 ;
-            paren  : "(" expr symbol expr ")" 4 ;
-            symbol : r"-|\+|\*|÷"             5 ;
-            num    : r"[0-9]+"                6 ;
+            expr   : num                      @ 1
+                   | paren                    @ 0
+                   | expr symbol expr         @ 3 ;
+            paren  : "(" expr symbol expr ")" @ 4 ;
+            symbol : r"-|\+|\*|÷"             @ 5 ;
+            num    : r"[0-9]+"                @ 6 ;
         "#
         .parse()
         .unwrap();
@@ -1076,11 +1076,11 @@ mod probabilistic_grammar {
         assert_grammar_branch_weights(&grammar1, &expected_weights1);
 
         let grammar2: Grammar = r#"
-            rule1 : branch1         0
-                  | branch1 branch1 0
-                  | "a"             766
-                  | branch1 "a"     0   ;
-            branch1 : "b"           1   ;
+            rule1 : branch1         @ 0
+                  | branch1 branch1 @ 0
+                  | "a"             @ 766
+                  | branch1 "a"     @ 0   ;
+            branch1 : "b"           @ 1   ;
         "#
         .parse()
         .unwrap();
@@ -1091,21 +1091,21 @@ mod probabilistic_grammar {
     #[test]
     fn reject_total_weight_is_zero() {
         let grammar1: Result<Grammar, _> = r#"
-            rule1 : branch1         0
-                  | branch1 branch1 0
-                  | "a"             0
-                  | branch1 "a"     0   ;
-            branch1 : "b"           1   ;
+            rule1 : branch1         @ 0
+                  | branch1 branch1 @ 0
+                  | "a"             @ 0
+                  | branch1 "a"     @ 0   ;
+            branch1 : "b"           @ 1   ;
         "#
         .parse();
         assert!(grammar1.is_err());
 
         let grammar2: Result<Grammar, _> = r#"
-            rule1 : branch1         4
-                  | branch1 branch1 3
-                  | "a"             2
-                  | branch1 "a"     1   ;
-            branch1 : "b"           0   ;
+            rule1 : branch1         @ 4
+                  | branch1 branch1 @ 3
+                  | "a"             @ 2
+                  | branch1 "a"     @ 1   ;
+            branch1 : "b"           @ 0   ;
         "#
         .parse();
         assert!(grammar2.is_err());
@@ -1114,21 +1114,21 @@ mod probabilistic_grammar {
     #[test]
     fn reject_negative_weight() {
         let grammar1: Result<Grammar, _> = r#"
-            rule1 : branch1         12
-                  | branch1 branch1 234
-                  | "a"             45
-                  | branch1 "a"     881 ;
-            branch1 : "b"           -1  ;
+            rule1 : branch1         @ 12
+                  | branch1 branch1 @ 234
+                  | "a"             @ 45
+                  | branch1 "a"     @ 881 ;
+            branch1 : "b"           @ -1  ;
         "#
         .parse();
         assert!(grammar1.is_err());
 
         let grammar2: Result<Grammar, _> = r#"
-            rule1 : branch1         12
-                  | branch1 branch1 -234
-                  | "a"             45
-                  | branch1 "a"     881  ;
-            branch1 : "b"           1    ;
+            rule1 : branch1         @ 12
+                  | branch1 branch1 @ -234
+                  | "a"             @ 45
+                  | branch1 "a"     @ 881  ;
+            branch1 : "b"           @ 1    ;
         "#
         .parse();
         assert!(grammar2.is_err());
@@ -1138,21 +1138,21 @@ mod probabilistic_grammar {
     fn reject_mixed_weight_rule() {
         // if part of a rule has assigned weights but another doesn't
         let grammar1: Result<Grammar, _> = r#"
-            rule1 : branch1         12
+            rule1 : branch1         @ 12
                   | branch1 branch1
-                  | "a"             45
-                  | branch1 "a"     881 ;
-            branch1 : "b"           1   ;
+                  | "a"             @ 45
+                  | branch1 "a"     @ 881 ;
+            branch1 : "b"           @ 1   ;
         "#
         .parse();
         assert!(grammar1.is_err());
 
         // but having one branch with weights and another branch without weights is ok
         let grammar2: Grammar = r#"
-            rule1 : branch1         12
-                  | branch1 branch1 7645
-                  | "a"             45
-                  | branch1 "a"     881 ;
+            rule1 : branch1         @ 12
+                  | branch1 branch1 @ 7645
+                  | "a"             @ 45
+                  | branch1 "a"     @ 881 ;
             branch1 : "b"               ;
         "#
         .parse()
@@ -1175,12 +1175,12 @@ mod probabilistic_grammar {
         .unwrap();
 
         let prob_grammar: Grammar = r#"
-            expr   : num              1
-                   | paren            2
-                   | expr symbol expr 3 ;
-            paren  : "(" expr symbol expr ")" 4 ;
-            symbol : r"-|\+|\*|÷" 5 ;
-            num    : r"[0-9]+" 6 ;
+            expr   : num              @ 1
+                   | paren            @ 2
+                   | expr symbol expr @ 3 ;
+            paren  : "(" expr symbol expr ")" @ 4 ;
+            symbol : r"-|\+|\*|÷" @ 5 ;
+            num    : r"[0-9]+" @ 6 ;
         "#
         .parse()
         .unwrap();
@@ -1209,13 +1209,13 @@ mod probabilistic_grammar {
         .unwrap();
 
         let prob_grammar: Grammar = r#"
-            expr   : num              1
-                   | paren            2
-                   | expr             0
-                   | expr symbol expr 3 ;
-            paren  : "(" expr symbol expr ")" 4 ;
-            symbol : r"-|\+|\*|÷" 5 ;
-            num    : r"[0-9]+" 6 ;
+            expr   : num                      @ 1
+                   | paren                    @ 2
+                   | expr                     @ 0
+                   | expr symbol expr         @ 3 ;
+            paren  : "(" expr symbol expr ")" @ 4 ;
+            symbol : r"-|\+|\*|÷"             @ 5 ;
+            num    : r"[0-9]+"                @ 6 ;
         "#
         .parse()
         .unwrap();
@@ -1232,13 +1232,13 @@ mod probabilistic_grammar {
     #[test]
     fn reject_non_u16_weight() {
         let grammar: Result<Grammar, _> = r#"
-            rule1 : "a" 65535 ;
+            rule1 : "a" @ 65535 ;
         "#
         .parse();
         assert!(grammar.is_ok());
 
         let grammar: Result<Grammar, _> = r#"
-            rule1 : "a" 65536 ;
+            rule1 : "a" @ 65536 ;
         "#
         .parse();
         assert!(grammar.is_err());

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -65,12 +65,21 @@ impl Grammar {
                 Expr::Or(v, i) => {
                     // TODO: might be better way to choose a random item from a filtered list
                     // will explore ways to avoid the vec allocation when we have benchmarks.
-                    let avail: Vec<_> = (0..v.len())
-                        .filter(|j| self.reachable(depth, *i, *j))
+                    // TODO: the weighted choosing is quite hacky, improve if possible
+                    let avail: Vec<_> = v
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(j, x)| {
+                            if self.reachable(depth, *i, j) {
+                                Some(x)
+                            } else {
+                                None
+                            }
+                        })
                         .collect();
-                    let arb_index = u.choose_iter(avail.iter())?;
-                    to_write.push((&v[*arb_index], depth));
-                    visitor.visit_or(*arb_index);
+                    let (choice, arb_index) = choose_weighted(u, &avail)?;
+                    to_write.push((choice, depth));
+                    visitor.visit_or(arb_index);
                 }
                 Expr::Concat(v) => {
                     to_write.extend(v.iter().map(|x| (x, depth)));
@@ -232,11 +241,37 @@ fn find_duplicates(names: &[String]) -> Option<HashSet<String>> {
     (!dups.is_empty()).then_some(dups)
 }
 
+/// Given a collection of (expression, weight) pairs, randomly choose an expression using
+/// the weights as probabilities. Returns the chosen expression and its index in the
+/// original collection.
+///
+/// Returns Err if `choices_weighted` is empty.
+fn choose_weighted<'a>(
+    u: &mut Unstructured,
+    choices_weighted: &[&'a (Expr, WeightType)],
+) -> arbitrary::Result<(&'a Expr, usize)> {
+    let total_weight: usize = choices_weighted.iter().map(|x| x.1).sum();
+    // error occurs if choices_weighted is empty
+    // add one to shift range from (0..total_weight) to (1..=total_weight)
+    let mut rem_weight = u.choose_index(total_weight)? + 1;
+    for (i, x) in choices_weighted.iter().enumerate() {
+        let w = x.1;
+        if w > 0 && rem_weight <= w {
+            return Ok((&x.0, i));
+        }
+        rem_weight -= w;
+    }
+    unreachable!("total_weight == sum of all weights")
+}
+
+/// Using usize to allow for easy interoperability with Unstructured::choose_index.
+pub(crate) type WeightType = usize;
+
 /// Branch `Expr`s (`Optional`, `Or`, `Repetition`) contain a `usize`
 /// which is index of the branch in the state machine (pre-ordered).
 #[derive(Debug)]
 enum Expr {
-    Or(Vec<Expr>, usize),
+    Or(Vec<(Expr, WeightType)>, usize),
     Concat(Vec<Expr>),
     Optional(Box<Expr>, usize),
     Repetition(Box<Expr>, u32, u32, usize),
@@ -272,7 +307,7 @@ impl Expr {
             Self::Or(x, i) => {
                 let mut res = Some(0u64);
                 for (j, child) in x.iter().enumerate() {
-                    let sub_res = child.how_many(rules, mem, reachable);
+                    let sub_res = child.0.how_many(rules, mem, reachable);
                     let child_reachable = sub_res.map_or(true, |x| x > 0);
                     if !child_reachable {
                         reachable[*i][j] += 1;
@@ -350,7 +385,7 @@ fn fmt_w_name<'a>(
 impl fmt::Display for Expr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
-            Self::Or(x, _) => fmt_w_name("or", x.iter(), f)?,
+            Self::Or(x, _) => fmt_w_name("or", x.iter().map(|(e, _w)| e), f)?,
             Self::Concat(x) => fmt_w_name("concat", x.iter().rev(), f)?,
             Self::Optional(x, _) => write!(f, "option({})", x)?,
             Self::Repetition(x, min, max, _) => write!(f, "repeat({}, {}, {})", x, min, max)?,
@@ -381,7 +416,10 @@ impl Expr {
             ir::Expr::Or(x) => {
                 let child = x
                     .into_iter()
-                    .map(|e| Self::try_new(e, names, reachable))
+                    .map(|(e, w)| {
+                        let child_e = Self::try_new(e, names, reachable)?;
+                        Ok((child_e, w))
+                    })
                     .collect::<Result<Vec<_>, _>>()?;
                 reachable.push(vec![0; child.len()]);
                 Self::Or(child, reachable.len() - 1)
@@ -920,6 +958,268 @@ mod tests {
         for depth in 1..=30 {
             let valid = success_count(&grammar, depth, 10);
             assert_eq!(valid, 10);
+        }
+    }
+}
+
+#[cfg(test)]
+mod probabilistic_grammar {
+    use super::*;
+
+    fn assert_grammar_branch_weights(grammar: &Grammar, expected_weights: &Vec<Vec<usize>>) {
+        assert_eq!(grammar.rules.len(), expected_weights.len());
+        for (rule, exp_w) in std::iter::zip(grammar.rules.iter(), expected_weights.into_iter()) {
+            assert!(matches!(rule, Expr::Or(_, _)));
+            if let Expr::Or(branches, _) = rule {
+                let branch_weights = branches.iter().map(|x| x.1).collect::<Vec<_>>();
+                assert_eq!(&branch_weights, exp_w);
+            }
+        }
+    }
+
+    #[test]
+    fn simple_parse_weighted() {
+        let grammar: Grammar = r#"
+            expr   : num                      1 
+                   | paren                    2
+                   | expr symbol expr         3 ;
+            paren  : "(" expr symbol expr ")" 4 ;
+            symbol : r"-|\+|\*|÷"             5 ;
+            num    : r"[0-9]+"                6 ;
+        "#
+        .parse()
+        .unwrap();
+
+        let expected_weights = vec![vec![1, 2, 3], vec![4], vec![5], vec![6]];
+        assert_grammar_branch_weights(&grammar, &expected_weights);
+    }
+
+    #[test]
+    fn reject_rule_names_start_with_number() {
+        let grammar1: Result<Grammar, _> = r#"
+            rule1: branch1 | branch2 | 3branch ;
+            branch1: "a";
+            branch2: "b";
+            3branch: "c";
+        "#
+        .parse();
+        assert!(grammar1.is_err());
+
+        let grammar2: Result<Grammar, _> = r#"
+            9rule: branch1 | branch2 | branch3 ;
+            branch1: "a";
+            branch2: "b";
+            branch3: "c";
+        "#
+        .parse();
+        assert!(grammar2.is_err());
+    }
+
+    #[test]
+    fn reject_number_in_between_concat() {
+        let grammar1: Result<Grammar, _> = r#"
+            rule1: branch1 314 branch2 | branch2 | branch3 ;
+            branch1: "a";
+            branch2: "b";
+            branch3: "c";
+        "#
+        .parse();
+        assert!(grammar1.is_err());
+
+        let grammar2: Result<Grammar, _> = r#"
+            rule1: branch1 branch2 | branch2 | branch3 ;
+            branch1: "a" "b" "c" 8 "d" 9;
+            branch2: "b";
+            branch3: "c";
+        "#
+        .parse();
+        assert!(grammar2.is_err());
+
+        let grammar2: Result<Grammar, _> = r#"
+            rule1: branch1 branch2 | branch2 | 0 branch3 ;
+            branch1: "a" "b" "c" "d";
+            branch2: "b";
+            branch3: "c";
+        "#
+        .parse();
+        assert!(grammar2.is_err());
+    }
+
+    #[test]
+    fn allow_leading_zero_weight() {
+        // Allow leading zeros to align with Rust's integer parsing behavior
+        let _grammar2: Grammar = r#"
+            expr   : num                      1 
+                   | paren                    0002000
+                   | expr symbol expr         3 ;
+            paren  : "(" expr symbol expr ")" 4 ;
+            symbol : r"-|\+|\*|÷"             5 ;
+            num    : r"[0-9]+"                6 ;
+        "#
+        .parse()
+        .unwrap();
+    }
+
+    #[test]
+    fn zero_weights_not_included() {
+        let grammar1: Grammar = r#"
+            expr   : num                      1 
+                   | paren                    0
+                   | expr symbol expr         3 ;
+            paren  : "(" expr symbol expr ")" 4 ;
+            symbol : r"-|\+|\*|÷"             5 ;
+            num    : r"[0-9]+"                6 ;
+        "#
+        .parse()
+        .unwrap();
+        let expected_weights1 = vec![vec![1, 3], vec![4], vec![5], vec![6]];
+        assert_grammar_branch_weights(&grammar1, &expected_weights1);
+
+        let grammar2: Grammar = r#"
+            rule1 : branch1         0
+                  | branch1 branch1 0
+                  | "a"             766
+                  | branch1 "a"     0   ;
+            branch1 : "b"           1   ;
+        "#
+        .parse()
+        .unwrap();
+        let expected_weights2 = vec![vec![766], vec![1]];
+        assert_grammar_branch_weights(&grammar2, &expected_weights2);
+    }
+
+    #[test]
+    fn reject_total_weight_is_zero() {
+        let grammar1: Result<Grammar, _> = r#"
+            rule1 : branch1         0
+                  | branch1 branch1 0
+                  | "a"             0
+                  | branch1 "a"     0   ;
+            branch1 : "b"           1   ;
+        "#
+        .parse();
+        assert!(grammar1.is_err());
+
+        let grammar2: Result<Grammar, _> = r#"
+            rule1 : branch1         4
+                  | branch1 branch1 3
+                  | "a"             2
+                  | branch1 "a"     1   ;
+            branch1 : "b"           0   ;
+        "#
+        .parse();
+        assert!(grammar2.is_err());
+    }
+
+    #[test]
+    fn reject_negative_weight() {
+        let grammar1: Result<Grammar, _> = r#"
+            rule1 : branch1         12
+                  | branch1 branch1 234
+                  | "a"             45
+                  | branch1 "a"     881 ;
+            branch1 : "b"           -1  ;
+        "#
+        .parse();
+        assert!(grammar1.is_err());
+
+        let grammar2: Result<Grammar, _> = r#"
+            rule1 : branch1         12
+                  | branch1 branch1 -234
+                  | "a"             45
+                  | branch1 "a"     881  ;
+            branch1 : "b"           1    ;
+        "#
+        .parse();
+        assert!(grammar2.is_err());
+    }
+
+    #[test]
+    fn reject_mixed_weight_rule() {
+        // if part of a rule has assigned weights but another doesn't
+        let grammar1: Result<Grammar, _> = r#"
+            rule1 : branch1         12
+                  | branch1 branch1 
+                  | "a"             45
+                  | branch1 "a"     881 ;
+            branch1 : "b"           1   ;
+        "#
+        .parse();
+        assert!(grammar1.is_err());
+
+        // but having one branch with weights and another branch without weights is ok
+        let grammar2: Grammar = r#"
+            rule1 : branch1         12
+                  | branch1 branch1 7645
+                  | "a"             45
+                  | branch1 "a"     881 ;
+            branch1 : "b"               ;
+        "#
+        .parse()
+        .unwrap();
+        assert_grammar_branch_weights(&grammar2, &vec![vec![12, 7645, 45, 881], vec![1]]);
+    }
+
+    #[test]
+    fn how_many_weighted() {
+        // non-zero probabilities should not affect how many, regardless of how "unlikely" that branch is to hit
+        let grammar: Grammar = r#"
+            expr   : num
+                   | paren
+                   | expr symbol expr ;
+            paren  : "(" expr symbol expr ")" ;
+            symbol : r"-|\+|\*|÷" ;
+            num    : r"[0-9]+" ;
+        "#
+        .parse()
+        .unwrap();
+
+        let prob_grammar: Grammar = r#"
+            expr   : num              1
+                   | paren            2
+                   | expr symbol expr 3 ;
+            paren  : "(" expr symbol expr ")" 4 ;
+            symbol : r"-|\+|\*|÷" 5 ;
+            num    : r"[0-9]+" 6 ;
+        "#
+        .parse()
+        .unwrap();
+
+        assert_eq!(grammar.how_many(None), prob_grammar.how_many(None));
+        for depth in 1..=100 {
+            assert_eq!(grammar.how_many(Some(depth)), prob_grammar.how_many(Some(depth)));
+        }
+    }
+
+    #[test]
+    fn how_many_zero_weight() {
+        // branches with non-zero weight should get filtered out during parsing and thus not affect `how_many` calculations
+        let grammar: Grammar = r#"
+            expr   : num
+                   | paren
+                   | expr symbol expr ;
+            paren  : "(" expr symbol expr ")" ;
+            symbol : r"-|\+|\*|÷" ;
+            num    : r"[0-9]+" ;
+        "#
+        .parse()
+        .unwrap();
+
+        let prob_grammar: Grammar = r#"
+            expr   : num              1
+                   | paren            2
+                   | expr             0
+                   | expr symbol expr 3 ;
+            paren  : "(" expr symbol expr ")" 4 ;
+            symbol : r"-|\+|\*|÷" 5 ;
+            num    : r"[0-9]+" 6 ;
+        "#
+        .parse()
+        .unwrap();
+
+        assert_eq!(grammar.how_many(None), prob_grammar.how_many(None));
+        for depth in 1..=100 {
+            assert_eq!(grammar.how_many(Some(depth)), prob_grammar.how_many(Some(depth)));
         }
     }
 }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -35,8 +35,8 @@ pub grammar bnf() for str {
         / _ x:concat_inner() _ { x }
 
     rule weighted_branch_inner() -> (Expr, WeightType)
-        = _ x:concat() __ w:weight() _ { (x, w) }
-        / _ x:concat_inner() __ w:weight() _ { (x, w) }
+        = _ x:concat() _ "@" _ w:weight() _ { (x, w) }
+        / _ x:concat_inner() _ "@" _ w:weight() _ { (x, w) }
 
     rule weight() -> WeightType
         = w:$(['0'..='9']+) {?

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -2,10 +2,18 @@
 
 use peg::parser;
 
+use crate::grammar::WeightType;
+
 /// The maxium repititions in `+` and `*` rules.
 /// This can be overriden with explicit range rules,
 /// e.g. `"3"{0,2345678}` repeats up to 2345678 `"3"`s.
 pub const MAX_REPEAT: u32 = 255;
+
+/// If `Or` branches are not given weights, then they all default to having the same
+/// weight of 1.
+/// 
+/// If this is ever changed, make sure the value is >= 1, otherwise grammar tests may fail.
+const DEFAULT_WEIGHT: usize = 1;
 
 parser! {
 /// This parser is not meant to efficient, since parsing the grammar is not meant to be
@@ -17,13 +25,21 @@ pub grammar bnf() for str {
     rule definition() -> (String, Expr)
         = _ s:reference() _ ":" _ e:branch() _ ";" _ { (s, e) }
 
+    // NOTE: the order of the below parse rules is important
     rule branch() -> Expr
-        = or()
-        / branch_inner()
+        = weighted_or()
+        / or()
 
     rule branch_inner() -> Expr
         = _ x:concat() _ { x }
         / _ x:concat_inner() _ { x }
+
+    rule weighted_branch_inner() -> (Expr, WeightType)
+        = _ x:concat() __ w:weight() _ { (x, w) }
+        / _ x:concat_inner() __ w:weight() _ { (x, w) }
+
+    rule weight() -> WeightType
+        = w:$(['0'..='9']+) {? w.parse().or(Err("can't parse weight to u64")) }
 
     rule concat_inner() -> Expr
         = rep()
@@ -44,7 +60,28 @@ pub grammar bnf() for str {
         = "(" _ r:branch() _ ")" { Expr::Group(Box::new(r)) }
 
     rule or() -> Expr
-        = l:(branch_inner() **<2,64> "|") { Expr::Or(l) }
+        = l:(branch_inner() **<1,64> "|") {?
+            let weighted_exprs = l.into_iter().map(|e| (e, DEFAULT_WEIGHT)).collect::<Vec<_>>();
+            let total_weight = weighted_exprs.len().checked_mul(DEFAULT_WEIGHT).ok_or("total weight does not fit in a usize")?;
+            if total_weight > 0 {
+                Ok(Expr::Or(weighted_exprs))
+            } else {
+                Err("total weight must be greater than 0")
+            }
+        }
+
+    rule weighted_or() -> Expr
+        = l:(weighted_branch_inner() **<1,64> "|") {?
+            // branches with 0 weight are filtered out during parsing
+            // this is done to not mess with how_many calculations
+            let positive_weights = l.into_iter().filter(|(_e, w)| *w > 0).collect::<Vec<_>>();
+            let total_weight = positive_weights.iter().map(|(_e, w)| w).try_fold(0usize, |acc, &x| acc.checked_add(x)).ok_or("total weight does not fit in a usize")?;
+            if total_weight > 0 {
+                Ok(Expr::Or(positive_weights))
+            } else {
+                Err("total weight must be greater than 0")
+            }
+        }
 
     rule rep() -> Expr
         = g:expression() _ "*" { Expr::Repetition(Box::new(g), 0, MAX_REPEAT) }
@@ -68,8 +105,11 @@ pub grammar bnf() for str {
     rule concat() -> Expr
         = l:(concat_inner() **<2,64> __) { Expr::Concat(l) }
 
+    // the parser is designed to assume parsing a weight if a token starts with a number.
+    // adding look-forward parsing to support identifiers that start with numbers is too difficult,
+    // going to restrict identifiers to start with a letter or underscore
     rule reference() -> String
-        = s:$(['a'..='z' | 'A'..='Z' | '_' | '0'..='9']+) { s.to_string() }
+        = s:$(['a'..='z' | 'A'..='Z' | '_'] ['a'..='z' | 'A'..='Z' | '_' | '0'..='9']*) { s.to_string() }
 
     rule literal() -> Expr
         = s:string() { Expr::Literal(s) }
@@ -122,7 +162,7 @@ pub grammar bnf() for str {
 
 #[derive(Debug)]
 pub enum Expr {
-    Or(Vec<Expr>),
+    Or(Vec<(Expr, WeightType)>),
     Concat(Vec<Expr>),
     Optional(Box<Expr>),
     Repetition(Box<Expr>, u32, u32),

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -11,7 +11,7 @@ pub const MAX_REPEAT: u32 = 255;
 
 /// If `Or` branches are not given weights, then they all default to having the same
 /// weight of 1.
-/// 
+///
 /// If this is ever changed, make sure the value is >= 1, otherwise grammar tests may fail.
 const DEFAULT_WEIGHT: usize = 1;
 
@@ -39,7 +39,12 @@ pub grammar bnf() for str {
         / _ x:concat_inner() __ w:weight() _ { (x, w) }
 
     rule weight() -> WeightType
-        = w:$(['0'..='9']+) {? w.parse().or(Err("can't parse weight to u64")) }
+        = w:$(['0'..='9']+) {?
+            // weights are parsed as u16 to avoid overflow issues when summing weights
+            w.parse::<u16>()
+                .and_then(|v| Ok(v as WeightType))
+                .map_err(|_| "can't parse weight to u16")
+        }
 
     rule concat_inner() -> Expr
         = rep()


### PR DESCRIPTION
TLDR; adds support for [probabilistic CFGs](https://en.m.wikipedia.org/wiki/Probabilistic_context-free_grammar) by extending the `Grammar` struct to support weighted `Or` branches.

## Why

Consider the following grammar for generating nested lists of numbers:
```
list   : "[" list "]"
       | number       ;
number : r"[0-9]+"    ;
```

Note that of the two branches of the `list` rule, the first is recursive while the second is terminal. If we then call `grammar.expression(..., None)`, there should be a chance it returns a list of nesting-depth in the order of `usize::MAX` [(source)](https://github.com/awslabs/spindle/blob/89b7cd6808fd5b82307d8ddb4303d95aec7326ba/src/grammar.rs#L57).

But in practice, since both branches have an equal probability of being selected, the expected nesting depth is just 2 [^1].

This early-stopping behaviour is further exaggerated when certain rules have smaller ratios of non-terminal to terminal branches.

## Solution

I would like to believe that this early-stopping behaviour is unintended, and we should give the user the possibility to opt-in to manually controlling probabilities of branches being selected. This PR implements the feature for users to append weights to each branch:
```
list   : "[" list "]" 90
       | number       10 ;
number : r"[0-9]+"       ;
```

Now, there is a 90% change of selecting the recursive list and only a 10% chance of terminating with a number. The expected nesting-depth of this list is now 9. (Previously the chances of getting a 9 deep list were <0.5%!)

Note that appending probabilities is opt-in -- if no probabilities are given by the user, all branches default to an equal probability of 1. In the above example, we put probabilities in the `list` rule but not `number` rule (doing so would be redundant). There are also checks done at parsing-time to make sure:
- There is no mix of branches with weights and branches without weights.
- Although 0 weights are allowed (a branch is never chosen), the sum of all branch weights must be strictly positive.

The of a rule do not have to sum up to a particular value -- they are relative. That is, the following two grammars have identical distributions:
```
list   : "[" list "]" 90
       | number       10 ;
number : r"[0-9]+"       ;
```
and
```
list   : "[" list "]" 1107
       | number       123 ;
number : r"[0-9]+"        ;
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[^1]: The nesting-depth follows a [geometric distribution](https://en.wikipedia.org/wiki/Geometric_distribution) with terminal-probability of 1/2.
